### PR TITLE
Add a dot at the end of chat lines during model replies to make the responses look smoother.

### DIFF
--- a/src/chat/chat_line.rs
+++ b/src/chat/chat_line.rs
@@ -420,19 +420,19 @@ impl ChatLineRef {
             return;
         };
 
-        if is_streaming && !text.is_empty() {
-            let output = format!("{}{}", text, "●");
-            inner.text_input(id!(input)).set_text(&output.trim());
-            inner.label(id!(plain_text_message)).set_text(&output.trim());
-            inner.markdown(id!(markdown_message)).set_text(&output.trim());
-        } else {
-            inner.text_input(id!(input)).set_text(text.trim());
-            inner.label(id!(plain_text_message)).set_text(text.trim());
-            inner.markdown(id!(markdown_message)).set_text(text.trim());
-        }
         match inner.edition_state {
-
+            
             ChatLineState::Editable | ChatLineState::NotEditable => {
+                if is_streaming && !text.is_empty() {
+                    let output = format!("{}{}", text, "●");
+                    inner.text_input(id!(input)).set_text(&output.trim());
+                    inner.label(id!(plain_text_message)).set_text(&output.trim());
+                    inner.markdown(id!(markdown_message)).set_text(&output.trim());
+                } else {
+                    inner.text_input(id!(input)).set_text(text.trim());
+                    inner.label(id!(plain_text_message)).set_text(text.trim());
+                    inner.markdown(id!(markdown_message)).set_text(text.trim());
+                }
 
                 // We know only AI assistant messages could be empty, so it is never
                 // displayed in user's chat lines.

--- a/src/chat/chat_line.rs
+++ b/src/chat/chat_line.rs
@@ -415,16 +415,24 @@ impl ChatLineRef {
         inner.label(id!(avatar_label)).set_text(text);
     }
 
-    pub fn set_message_text(&mut self, cx: &mut Cx, text: &str) {
+    pub fn set_message_text(&mut self, cx: &mut Cx, text: &str, is_streaming: bool) {
         let Some(mut inner) = self.borrow_mut() else {
             return;
         };
 
+        if is_streaming && !text.is_empty() {
+            let output = format!("{}{}", text, "●");
+            inner.text_input(id!(input)).set_text(&output.trim());
+            inner.label(id!(plain_text_message)).set_text(&output.trim());
+            inner.markdown(id!(markdown_message)).set_text(&output.trim());
+        } else {
+            inner.text_input(id!(input)).set_text(text.trim());
+            inner.label(id!(plain_text_message)).set_text(text.trim());
+            inner.markdown(id!(markdown_message)).set_text(text.trim());
+        }
         match inner.edition_state {
+
             ChatLineState::Editable | ChatLineState::NotEditable => {
-                inner.text_input(id!(input)).set_text(text.trim());
-                inner.label(id!(plain_text_message)).set_text(text.trim());
-                inner.markdown(id!(markdown_message)).set_text(text.trim());
 
                 // We know only AI assistant messages could be empty, so it is never
                 // displayed in user's chat lines.

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -419,7 +419,7 @@ live_design! {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-pub enum State {
+enum State {
     /// `Unknown` is simply the default state, meaning the state has not been loaded yet,
     /// and therefore indicates a development error if it is encountered.
     #[default]

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -419,7 +419,7 @@ live_design! {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-enum State {
+pub enum State {
     /// `Unknown` is simply the default state, meaning the state has not been loaded yet,
     /// and therefore indicates a development error if it is encountered.
     #[default]
@@ -882,7 +882,6 @@ impl ChatPanel {
                     chat_line_item.set_regenerate_button_visible(true);
                 };
 
-                chat_line_item.set_message_text(cx, &chat_line_data.content);
                 chat_line_item.set_message_id(chat_line_data.id);
 
                 // Disable actions for the last chat line when model is streaming
@@ -894,8 +893,10 @@ impl ChatPanel {
                     }
                 ) && item_id == messages_count - 1
                 {
+                    chat_line_item.set_message_text(cx, &chat_line_data.content, true);
                     chat_line_item.set_actions_enabled(cx, false);
                 } else {
+                    chat_line_item.set_message_text(cx, &chat_line_data.content, false);
                     chat_line_item.set_actions_enabled(cx, true);
                 }
 


### PR DESCRIPTION
There is a problem: Sometimes Makepad cannot immediately render this dot.