### PR TITLE
Override the original font

### DIFF
--- a/src/chat/chat_line.rs
+++ b/src/chat/chat_line.rs
@@ -65,7 +65,7 @@ live_design! {
         width: Fill, height: Fit,
         font_size: 10.0,
         draw_normal: {
-            text_style: { height_factor: (TEXT_HEIGHT_FACTOR), line_spacing: (LINE_SPACING) }
+            text_style: <REGULAR_FONT>{ height_factor: (TEXT_HEIGHT_FACTOR), line_spacing: (LINE_SPACING) }
         }
         draw_italic: {
             text_style: { height_factor: (TEXT_HEIGHT_FACTOR), line_spacing: (LINE_SPACING) }


### PR DESCRIPTION
I tried overriding the font style in markdown, and it seems to have worked.
![截图 2024-09-30 14-56-46](https://github.com/user-attachments/assets/11d0c0fe-e694-48d3-a069-91d9695ef39e)
