### PR TITLE
refactor ModelSelectorAction

### DIFF
--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -343,7 +343,7 @@ impl WidgetMatchEvent for ModelSelector {
         }
 
         for action in actions {
-            match action.as_widget_action().cast() {
+            match action.cast() {
                 ModelSelectorAction::Selected(_) => {
                     self.hide_options(cx);
                 }

--- a/src/chat/model_selector_list.rs
+++ b/src/chat/model_selector_list.rs
@@ -112,18 +112,11 @@ pub struct ModelSelectorList {
 
 impl Widget for ModelSelectorList {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        let widget_uid = self.widget_uid();
         for (id, item) in self.items.iter_mut() {
             let actions = cx.capture_actions(|cx| item.handle_event(cx, event, scope));
             if let Some(fd) = item.as_view().finger_down(&actions) {
                 if fd.tap_count == 1 {
-                    cx.widget_action(
-                        widget_uid,
-                        &scope.path,
-                        ModelSelectorAction::Selected(
-                            self.map_to_downloaded_files.get(id).unwrap().clone(),
-                        ),
-                    );
+                    cx.action(ModelSelectorAction::Selected(self.map_to_downloaded_files.get(id).unwrap().clone()));
                 }
             }
         }


### PR DESCRIPTION
To avoid branch conflicts, I didn't modify the code
```rust
for action in actions
            .iter()
            .filter_map(|action| action.as_widget_action())
```

 in the `chat_panel` for this commit because I already made those changes in pr #293 .