### PR TITLE
Signals to explicit actions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,8 @@ use crate::data::store::*;
 use crate::landing::model_files_item::ModelFileItemAction;
 use crate::shared::actions::{ChatAction, DownloadAction};
 use crate::shared::download_notification_popup::{
-    DownloadNotificationPopupAction, DownloadNotificationPopupWidgetRefExt, DownloadResult, PopupAction
+    DownloadNotificationPopupAction, DownloadNotificationPopupWidgetRefExt, DownloadResult,
+    PopupAction,
 };
 use crate::shared::popup_notification::PopupNotificationWidgetRefExt;
 use makepad_widgets::*;
@@ -189,6 +190,8 @@ impl MatchEvent for App {
             );
 
         for action in actions.iter() {
+            self.store.handle_action(action);
+
             match action.cast() {
                 StoreAction::Search(keywords) => {
                     self.store.search.load_search_results(keywords);
@@ -248,7 +251,9 @@ impl MatchEvent for App {
                 DownloadNotificationPopupAction::ActionLinkClicked
                     | DownloadNotificationPopupAction::CloseButtonClicked
             ) {
-                self.ui.popup_notification(id!(popup_notification)).close(cx);
+                self.ui
+                    .popup_notification(id!(popup_notification))
+                    .close(cx);
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -155,11 +155,6 @@ impl LiveRegister for App {
 
 impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
-        // Process all possible store incoming events
-        if let Event::Signal = event {
-            self.ui.redraw(cx);
-        }
-
         let scope = &mut Scope::with_data(&mut self.store);
         self.ui.handle_event(cx, event, scope);
         self.match_event(cx, event);

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::chat::chat_panel::ChatPanelAction;
+use crate::data::downloads::download::DownloadFileAction;
 use crate::data::downloads::DownloadPendingNotification;
 use crate::data::store::*;
 use crate::landing::model_files_item::ModelFileItemAction;
@@ -185,9 +186,7 @@ impl MatchEvent for App {
         for action in actions.iter() {
             self.store.handle_action(action);
 
-            if let Some(_) =
-                action.downcast_ref::<crate::data::downloads::download::DownloadFileAction>()
-            {
+            if let Some(_) = action.downcast_ref::<DownloadFileAction>() {
                 self.notify_downloaded_files(cx);
             }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,7 +157,6 @@ impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
         // Process all possible store incoming events
         if let Event::Signal = event {
-            self.notify_downloaded_files(cx);
             self.ui.redraw(cx);
         }
 
@@ -190,6 +189,12 @@ impl MatchEvent for App {
 
         for action in actions.iter() {
             self.store.handle_action(action);
+
+            if let Some(_) =
+                action.downcast_ref::<crate::data::downloads::download::DownloadFileAction>()
+            {
+                self.notify_downloaded_files(cx);
+            }
 
             match action.cast() {
                 StoreAction::Search(keywords) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,7 +157,6 @@ impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
         // Process all possible store incoming events
         if let Event::Signal = event {
-            self.store.process_event_signal();
             self.notify_downloaded_files(cx);
             self.ui.redraw(cx);
         }

--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -73,13 +73,6 @@ impl Widget for ChatHistory {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.deref.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
-
-        // TODO This is a hack to redraw the chat history and reflect the
-        // name change on the first message sent.
-        // Maybe we should send and receive an action here?
-        if let Event::Signal = event {
-            self.redraw(cx);
-        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -9,7 +9,7 @@ use crate::{
         model_selector_list::ModelSelectorAction,
     },
     data::{
-        chats::chat::{Chat, ChatMessage},
+        chats::chat::{Chat, ChatEntityAction, ChatMessage},
         store::Store,
     },
     shared::actions::ChatAction,
@@ -497,7 +497,7 @@ impl WidgetMatchEvent for ChatPanel {
         let store = scope.data.get_mut::<Store>().unwrap();
 
         for action in actions {
-            if let Some(_) = action.downcast_ref::<crate::data::chats::chat::ChatAction>() {
+            if let Some(_) = action.downcast_ref::<ChatEntityAction>() {
                 match self.state {
                     State::ModelSelectedWithChat {
                         is_streaming: true,

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -9,7 +9,7 @@ use crate::{
         model_selector_list::ModelSelectorAction,
     },
     data::{
-        chats::chat::{Chat, ChatEntityAction, ChatMessage},
+        chats::chat::{Chat, ChatEntityAction, ChatID, ChatMessage},
         store::Store,
     },
     shared::actions::ChatAction,
@@ -497,21 +497,23 @@ impl WidgetMatchEvent for ChatPanel {
         let store = scope.data.get_mut::<Store>().unwrap();
 
         for action in actions {
-            if let Some(_) = action.downcast_ref::<ChatEntityAction>() {
-                match self.state {
-                    State::ModelSelectedWithChat {
-                        is_streaming: true,
-                        sticked_to_bottom,
-                        ..
-                    } => {
-                        if sticked_to_bottom {
-                            self.scroll_messages_to_bottom(cx);
-                        }
+            if let Some(action) = action.downcast_ref::<ChatEntityAction>() {
+                if get_chat_id(store) == Some(action.chat_id) {
+                    match self.state {
+                        State::ModelSelectedWithChat {
+                            is_streaming: true,
+                            sticked_to_bottom,
+                            ..
+                        } => {
+                            if sticked_to_bottom {
+                                self.scroll_messages_to_bottom(cx);
+                            }
 
-                        // Redraw because we expect to see new or updated chat entries
-                        self.redraw(cx);
+                            // Redraw because we expect to see new or updated chat entries
+                            self.redraw(cx);
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }
@@ -933,4 +935,8 @@ fn get_model_initial_letter(store: &Store) -> Option<char> {
 
 fn get_chat_messages(store: &Store) -> Option<Ref<Vec<ChatMessage>>> {
     get_chat(store).map(|chat| Ref::map(chat.borrow(), |chat| &chat.messages))
+}
+
+fn get_chat_id(store: &Store) -> Option<ChatID> {
+    get_chat(store).map(|chat| chat.borrow().id)
 }

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -466,24 +466,6 @@ impl Widget for ChatPanel {
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
         self.update_state(scope);
-
-        if let Event::Signal = event {
-            match self.state {
-                State::ModelSelectedWithChat {
-                    is_streaming: true,
-                    sticked_to_bottom,
-                    ..
-                } => {
-                    if sticked_to_bottom {
-                        self.scroll_messages_to_bottom(cx);
-                    }
-
-                    // Redraw because we expect to see new or updated chat entries
-                    self.redraw(cx);
-                }
-                _ => {}
-            }
-        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
@@ -513,6 +495,26 @@ impl Widget for ChatPanel {
 impl WidgetMatchEvent for ChatPanel {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let store = scope.data.get_mut::<Store>().unwrap();
+
+        for action in actions {
+            if let Some(_) = action.downcast_ref::<crate::data::chats::chat::ChatAction>() {
+                match self.state {
+                    State::ModelSelectedWithChat {
+                        is_streaming: true,
+                        sticked_to_bottom,
+                        ..
+                    } => {
+                        if sticked_to_bottom {
+                            self.scroll_messages_to_bottom(cx);
+                        }
+
+                        // Redraw because we expect to see new or updated chat entries
+                        self.redraw(cx);
+                    }
+                    _ => {}
+                }
+            }
+        }
 
         for action in actions
             .iter()

--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -124,10 +124,6 @@ impl Chat {
     }
 
     pub fn load(path: PathBuf, chats_dir: PathBuf) -> Result<Self> {
-        Cx::post_action(ChatEntityAction {
-            chat_id: 0,
-            kind: ChatEntityActionKind::StreamingDone,
-        });
         match read_from_file(path) {
             Ok(json) => {
                 let data: ChatData = serde_json::from_str(&json)?;

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -2,7 +2,7 @@ pub mod chat;
 pub mod model_loader;
 
 use anyhow::{Context, Result};
-use chat::{Chat, ChatAction, ChatID};
+use chat::{Chat, ChatEntityAction, ChatID};
 use makepad_widgets::ActionTrait;
 use model_loader::ModelLoader;
 use moly_backend::Backend;
@@ -198,7 +198,7 @@ impl Chats {
     }
 
     pub fn handle_action(&mut self, action: &Box<dyn ActionTrait>) {
-        if let Some(action) = action.downcast_ref::<ChatAction>() {
+        if let Some(action) = action.downcast_ref::<ChatEntityAction>() {
             if let Some(chat) = self.get_chat_by_id(action.chat_id) {
                 if chat.borrow().id == action.chat_id {
                     chat.borrow_mut().handle_action(action);

--- a/src/data/chats/model_loader.rs
+++ b/src/data/chats/model_loader.rs
@@ -12,8 +12,9 @@ use std::{
     thread,
 };
 
+/// Message emitted when the model loader status is updated.
 #[derive(Debug)]
-pub struct ModelLoaderAction;
+pub struct ModelLoaderStatusChanged;
 
 /// All posible states in which the loader can be.
 #[derive(Debug, Default, Clone)]
@@ -87,7 +88,6 @@ impl ModelLoader {
             Err(anyhow!("Internal communication error"))
         };
 
-        Cx::post_action(ModelLoaderAction);
         result
     }
 
@@ -107,6 +107,7 @@ impl ModelLoader {
 
     fn set_status(&mut self, status: ModelLoaderStatus) {
         self.0.lock().unwrap().status = status;
+        Cx::post_action(ModelLoaderStatusChanged);
     }
 
     fn set_file_id(&mut self, file_id: Option<FileID>) {

--- a/src/data/chats/model_loader.rs
+++ b/src/data/chats/model_loader.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use makepad_widgets::SignalToUI;
+use makepad_widgets::Cx;
 use moly_protocol::{
     data::FileID,
     protocol::{Command, LoadModelOptions, LoadModelResponse, LoadedModelInfo},
@@ -11,6 +11,9 @@ use std::{
     },
     thread,
 };
+
+#[derive(Debug)]
+pub struct ModelLoaderAction;
 
 /// All posible states in which the loader can be.
 #[derive(Debug, Default, Clone)]
@@ -84,7 +87,7 @@ impl ModelLoader {
             Err(anyhow!("Internal communication error"))
         };
 
-        SignalToUI::set_ui_signal();
+        Cx::post_action(ModelLoaderAction);
         result
     }
 

--- a/src/data/downloads/download.rs
+++ b/src/data/downloads/download.rs
@@ -7,7 +7,7 @@ use std::thread;
 
 #[derive(Debug)]
 pub struct DownloadFileAction {
-    pub id: FileID,
+    pub file_id: FileID,
     kind: DownloadFileActionKind,
 }
 
@@ -60,20 +60,20 @@ impl Download {
                         FileDownloadResponse::Completed(_completed) => {
                             is_done = true;
                             Cx::post_action(DownloadFileAction {
-                                id: file_id.clone(),
+                                file_id: file_id.clone(),
                                 kind: DownloadFileActionKind::StreamingDone,
                             });
                         }
                         FileDownloadResponse::Progress(_file, value) => {
                             Cx::post_action(DownloadFileAction {
-                                id: file_id.clone(),
+                                file_id: file_id.clone(),
                                 kind: DownloadFileActionKind::Progress(value as f64),
                             })
                         }
                     },
                     Err(err) => {
                         Cx::post_action(DownloadFileAction {
-                            id: file_id.clone(),
+                            file_id: file_id.clone(),
                             kind: DownloadFileActionKind::Error,
                         });
 

--- a/src/data/downloads/download.rs
+++ b/src/data/downloads/download.rs
@@ -1,4 +1,4 @@
-use makepad_widgets::{Cx, SignalToUI};
+use makepad_widgets::Cx;
 use moly_backend::Backend;
 use moly_protocol::data::*;
 use moly_protocol::protocol::{Command, FileDownloadResponse};
@@ -84,8 +84,6 @@ impl Download {
                 break;
             }
 
-            // TODO: Still needed, probably because of the root redraw.
-            SignalToUI::set_ui_signal();
             if is_done {
                 break;
             }

--- a/src/data/downloads/mod.rs
+++ b/src/data/downloads/mod.rs
@@ -232,7 +232,7 @@ impl Downloads {
 
     pub fn handle_action(&mut self, action: &Action) {
         if let Some(action) = action.downcast_ref::<DownloadFileAction>() {
-            if let Some(download) = self.current_downloads.get_mut(&action.id) {
+            if let Some(download) = self.current_downloads.get_mut(&action.file_id) {
                 download.handle_action(action);
             }
         }

--- a/src/data/downloads/mod.rs
+++ b/src/data/downloads/mod.rs
@@ -1,7 +1,8 @@
 pub mod download;
 
 use anyhow::{Context, Result};
-use download::{Download, DownloadState};
+use download::{Download, DownloadFileAction, DownloadState};
+use makepad_widgets::Action;
 use moly_backend::Backend;
 use moly_protocol::{
     data::{DownloadedFile, File, FileID, Model, PendingDownload, PendingDownloadsStatus},
@@ -229,15 +230,21 @@ impl Downloads {
         })
     }
 
-    /// This function is invoked when the Makepad signal is received. It updates the
+    pub fn handle_action(&mut self, action: &Action) {
+        if let Some(action) = action.downcast_ref::<DownloadFileAction>() {
+            if let Some(download) = self.current_downloads.get_mut(&action.id) {
+                download.handle_action(action);
+            }
+        }
+    }
+
+    /// This function is invoked after handling a download file action. It updates the
     /// download progress and state of the downloads, based in the active downloads
     /// but also retrieving fresh data from the backend.
     pub fn refresh_downloads_data(&mut self) -> Vec<FileID> {
         let mut completed_download_ids = Vec::new();
 
         for (id, download) in &mut self.current_downloads {
-            download.process_download_progress();
-
             if let Some(pending) = self
                 .pending_downloads
                 .iter_mut()

--- a/src/data/search/mod.rs
+++ b/src/data/search/mod.rs
@@ -1,6 +1,6 @@
 mod faked_models;
 
-use makepad_widgets::{Action, Cx, SignalToUI};
+use makepad_widgets::{Action, Cx};
 use moly_backend::Backend;
 use moly_protocol::data::*;
 use moly_protocol::protocol::Command;
@@ -198,7 +198,6 @@ impl Search {
                         self.set_models(models.clone());
                     } else {
                         self.set_models(vec![]);
-                        // SignalToUI::set_ui_signal();
                         eprintln!("Client was not expecting to receive results");
                     }
                 }
@@ -208,9 +207,6 @@ impl Search {
                     eprintln!("Error fetching models from the server");
                 }
             }
-
-            // TODO: This is still needed for some reason.
-            SignalToUI::set_ui_signal();
         }
     }
 

--- a/src/data/search/mod.rs
+++ b/src/data/search/mod.rs
@@ -1,12 +1,11 @@
 mod faked_models;
 
-use anyhow::{anyhow, Result};
-use makepad_widgets::SignalToUI;
+use makepad_widgets::{Action, Cx, SignalToUI};
 use moly_backend::Backend;
 use moly_protocol::data::*;
 use moly_protocol::protocol::Command;
 use std::rc::Rc;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::channel;
 use std::thread;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -17,6 +16,8 @@ pub enum SortCriteria {
     MostLikes,
     LeastLikes,
 }
+
+#[derive(Debug)]
 pub enum SearchAction {
     Results(Vec<Model>),
     Error,
@@ -40,21 +41,16 @@ pub struct Search {
     pub models: Vec<Model>,
     pub sorted_by: SortCriteria,
     pub keyword: Option<String>,
-    pub sender: Sender<SearchAction>,
-    pub receiver: Receiver<SearchAction>,
     pub state: SearchState,
 }
 
 impl Search {
     pub fn new(backend: Rc<Backend>) -> Self {
-        let (tx, rx) = channel();
         let search = Self {
             backend,
             models: Vec::new(),
             sorted_by: SortCriteria::MostDownloads,
             keyword: None,
-            sender: tx,
-            receiver: rx,
             state: SearchState::Idle,
         };
         search
@@ -74,7 +70,6 @@ impl Search {
 
         let (tx, rx) = channel();
 
-        let store_search_tx = self.sender.clone();
         self.backend
             .as_ref()
             .command_sender
@@ -85,14 +80,13 @@ impl Search {
             if let Ok(response) = rx.recv() {
                 match response {
                     Ok(models) => {
-                        store_search_tx.send(SearchAction::Results(models)).unwrap();
+                        Cx::post_action(SearchAction::Results(models));
                     }
                     Err(err) => {
                         eprintln!("Error fetching models: {:?}", err);
-                        store_search_tx.send(SearchAction::Error).unwrap();
+                        Cx::post_action(SearchAction::Error);
                     }
                 }
-                SignalToUI::set_ui_signal();
             }
         });
     }
@@ -114,7 +108,6 @@ impl Search {
 
         let (tx, rx) = channel();
 
-        let store_search_tx = self.sender.clone();
         self.backend
             .as_ref()
             .command_sender
@@ -125,14 +118,13 @@ impl Search {
             if let Ok(response) = rx.recv() {
                 match response {
                     Ok(models) => {
-                        store_search_tx.send(SearchAction::Results(models)).unwrap();
+                        Cx::post_action(SearchAction::Results(models));
                     }
                     Err(err) => {
                         eprintln!("Error fetching models: {:?}", err);
-                        store_search_tx.send(SearchAction::Error).unwrap();
+                        Cx::post_action(SearchAction::Error);
                     }
                 }
-                SignalToUI::set_ui_signal();
             }
         });
     }
@@ -182,8 +174,8 @@ impl Search {
         self.sort_models(self.sorted_by);
     }
 
-    pub fn process_results(&mut self) -> Result<Option<Vec<Model>>> {
-        for msg in self.receiver.try_iter() {
+    pub fn handle_action(&mut self, action: &Action) {
+        if let Some(msg) = action.downcast_ref::<SearchAction>() {
             match msg {
                 SearchAction::Results(models) => {
                     let previous_state = self.state.to_owned();
@@ -203,18 +195,23 @@ impl Search {
                             }
                             None => {}
                         }
-                        return Ok(Some(models));
+                        self.set_models(models.clone());
                     } else {
-                        return Err(anyhow!("Client was not expecting to receive results"));
+                        self.set_models(vec![]);
+                        // SignalToUI::set_ui_signal();
+                        eprintln!("Client was not expecting to receive results");
                     }
                 }
                 SearchAction::Error => {
                     self.state = SearchState::Errored;
-                    return Err(anyhow!("Error fetching models from the server"));
+                    self.set_models(vec![]);
+                    eprintln!("Error fetching models from the server");
                 }
             }
+
+            // TODO: This is still needed for some reason.
+            SignalToUI::set_ui_signal();
         }
-        Ok(None)
     }
 
     pub fn is_pending(&self) -> bool {

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -1,5 +1,5 @@
 use super::chats::chat::ChatID;
-use super::chats::model_loader::ModelLoaderAction;
+use super::chats::model_loader::ModelLoaderStatusChanged;
 use super::downloads::download::DownloadFileAction;
 use super::filesystem::project_dirs;
 use super::preferences::Preferences;
@@ -268,7 +268,7 @@ impl Store {
         self.search.handle_action(action);
         self.downloads.handle_action(action);
 
-        if let Some(_) = action.downcast_ref::<ModelLoaderAction>() {
+        if let Some(_) = action.downcast_ref::<ModelLoaderStatusChanged>() {
             self.update_load_model();
         }
 

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -7,7 +7,7 @@ use super::search::SortCriteria;
 use super::{chats::Chats, downloads::Downloads, search::Search};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use makepad_widgets::{Action, ActionDefaultRef, DefaultNone, SignalToUI};
+use makepad_widgets::{Action, ActionDefaultRef, DefaultNone};
 use moly_backend::Backend;
 use moly_protocol::data::{Author, DownloadedFile, File, FileID, Model, ModelID, PendingDownload};
 use std::rc::Rc;
@@ -260,7 +260,6 @@ impl Store {
         self.search
             .update_downloaded_file_in_search_results(&file_id, false);
 
-        SignalToUI::set_ui_signal();
         Ok(())
     }
 

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -1,5 +1,6 @@
 use super::chats::chat::ChatID;
 use super::chats::model_loader::ModelLoaderAction;
+use super::downloads::download::DownloadFileAction;
 use super::filesystem::project_dirs;
 use super::preferences::Preferences;
 use super::search::SortCriteria;
@@ -266,14 +267,15 @@ impl Store {
     pub fn handle_action(&mut self, action: &Action) {
         self.chats.handle_action(action);
         self.search.handle_action(action);
+        self.downloads.handle_action(action);
 
         if let Some(_) = action.downcast_ref::<ModelLoaderAction>() {
             self.update_load_model();
         }
-    }
 
-    pub fn process_event_signal(&mut self) {
-        self.update_downloads();
+        if let Some(_) = action.downcast_ref::<DownloadFileAction>() {
+            self.update_downloads();
+        }
     }
 
     fn update_downloads(&mut self) {

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -265,6 +265,7 @@ impl Store {
 
     pub fn handle_action(&mut self, action: &Action) {
         self.chats.handle_action(action);
+        self.search.handle_action(action);
 
         if let Some(_) = action.downcast_ref::<ModelLoaderAction>() {
             self.update_load_model();
@@ -273,21 +274,6 @@ impl Store {
 
     pub fn process_event_signal(&mut self) {
         self.update_downloads();
-        self.update_search_results();
-    }
-
-    fn update_search_results(&mut self) {
-        match self.search.process_results() {
-            Ok(Some(models)) => {
-                self.search.set_models(models);
-            }
-            Ok(None) => {
-                // No results arrived, do nothing
-            }
-            Err(_) => {
-                self.search.set_models(vec![]);
-            }
-        }
     }
 
     fn update_downloads(&mut self) {

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -5,7 +5,7 @@ use super::search::SortCriteria;
 use super::{chats::Chats, downloads::Downloads, search::Search};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use makepad_widgets::{DefaultNone, SignalToUI, ActionDefaultRef};
+use makepad_widgets::{Action, ActionDefaultRef, DefaultNone, SignalToUI};
 use moly_backend::Backend;
 use moly_protocol::data::{Author, DownloadedFile, File, FileID, Model, ModelID, PendingDownload};
 use std::rc::Rc;
@@ -262,9 +262,12 @@ impl Store {
         Ok(())
     }
 
+    pub fn handle_action(&mut self, action: &Action) {
+        self.chats.handle_action(action);
+    }
+
     pub fn process_event_signal(&mut self) {
         self.update_downloads();
-        self.update_chat_messages();
         self.update_search_results();
         self.update_load_model();
     }
@@ -281,13 +284,6 @@ impl Store {
                 self.search.set_models(vec![]);
             }
         }
-    }
-
-    fn update_chat_messages(&mut self) {
-        let Some(chat) = self.chats.get_current_chat() else {
-            return;
-        };
-        chat.borrow_mut().update_messages();
     }
 
     fn update_downloads(&mut self) {

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -1,4 +1,5 @@
 use super::chats::chat::ChatID;
+use super::chats::model_loader::ModelLoaderAction;
 use super::filesystem::project_dirs;
 use super::preferences::Preferences;
 use super::search::SortCriteria;
@@ -264,12 +265,15 @@ impl Store {
 
     pub fn handle_action(&mut self, action: &Action) {
         self.chats.handle_action(action);
+
+        if let Some(_) = action.downcast_ref::<ModelLoaderAction>() {
+            self.update_load_model();
+        }
     }
 
     pub fn process_event_signal(&mut self) {
         self.update_downloads();
         self.update_search_results();
-        self.update_load_model();
     }
 
     fn update_search_results(&mut self) {

--- a/src/landing/download_item.rs
+++ b/src/landing/download_item.rs
@@ -1,6 +1,9 @@
-use crate::shared::{
-    actions::DownloadAction,
-    utils::{format_model_downloaded_size, format_model_size},
+use crate::{
+    data::downloads::download::DownloadFileAction,
+    shared::{
+        actions::DownloadAction,
+        utils::{format_model_downloaded_size, format_model_size},
+    },
 };
 use makepad_widgets::*;
 use moly_protocol::data::{FileID, PendingDownload, PendingDownloadsStatus};
@@ -341,6 +344,14 @@ impl Widget for DownloadItem {
 
 impl WidgetMatchEvent for DownloadItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+        for actions in actions {
+            if let Some(action) = actions.downcast_ref::<DownloadFileAction>() {
+                if self.file_id.as_ref() == Some(&action.id) {
+                    self.redraw(cx);
+                }
+            }
+        }
+
         for button_id in [id!(play_button), id!(retry_button)] {
             if self.button(button_id).clicked(&actions) {
                 let Some(file_id) = &self.file_id else { return };

--- a/src/landing/download_item.rs
+++ b/src/landing/download_item.rs
@@ -346,7 +346,7 @@ impl WidgetMatchEvent for DownloadItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         for actions in actions {
             if let Some(action) = actions.downcast_ref::<DownloadFileAction>() {
-                if self.file_id.as_ref() == Some(&action.id) {
+                if self.file_id.as_ref() == Some(&action.file_id) {
                     self.redraw(cx);
                 }
             }

--- a/src/landing/landing_screen.rs
+++ b/src/landing/landing_screen.rs
@@ -1,3 +1,4 @@
+use crate::data::search::SearchAction;
 use crate::data::store::{Store, StoreAction};
 use crate::landing::model_list::ModelListAction;
 use crate::landing::search_bar::SearchBarWidgetExt;
@@ -147,6 +148,10 @@ impl Widget for LandingScreen {
 impl WidgetMatchEvent for LandingScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         for action in actions.iter() {
+            if let Some(_) = action.downcast_ref::<SearchAction>() {
+                self.redraw(cx);
+            }
+
             match action.cast() {
                 ModelListAction::ScrolledAtTop => {
                     if self.search_bar_state == SearchBarState::CollapsedWithoutFilters {

--- a/src/landing/model_files_item.rs
+++ b/src/landing/model_files_item.rs
@@ -322,7 +322,7 @@ impl WidgetMatchEvent for ModelFilesItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         for actions in actions {
             if let Some(action) = actions.downcast_ref::<DownloadFileAction>() {
-                if self.file_id.as_ref() == Some(&action.id) {
+                if self.file_id.as_ref() == Some(&action.file_id) {
                     self.redraw(cx);
                 }
             }

--- a/src/landing/model_files_item.rs
+++ b/src/landing/model_files_item.rs
@@ -3,7 +3,7 @@ use moly_protocol::data::{File, FileID, PendingDownloadsStatus};
 
 use super::model_files_tags::ModelFilesTagsWidgetExt;
 use crate::{
-    data::store::FileWithDownloadInfo,
+    data::{downloads::download::DownloadFileAction, store::FileWithDownloadInfo},
     shared::{
         actions::{ChatAction, DownloadAction},
         utils::format_model_size,
@@ -320,6 +320,14 @@ impl Widget for ModelFilesItem {
 
 impl WidgetMatchEvent for ModelFilesItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+        for actions in actions {
+            if let Some(action) = actions.downcast_ref::<DownloadFileAction>() {
+                if self.file_id.as_ref() == Some(&action.id) {
+                    self.redraw(cx);
+                }
+            }
+        }
+
         let Some(file_id) = self.file_id.clone() else {
             return;
         };

--- a/src/landing/model_list.rs
+++ b/src/landing/model_list.rs
@@ -1,3 +1,4 @@
+use crate::data::search::SearchAction;
 use crate::data::store::{Store, StoreAction};
 use crate::landing::search_loading::SearchLoadingWidgetExt;
 use makepad_widgets::*;
@@ -76,10 +77,6 @@ impl Widget for ModelList {
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
 
-        if let Event::Signal = event {
-            self.loading_delay = cx.start_timeout(0.2);
-        }
-
         if self.loading_delay.is_event(event).is_some() {
             self.update_loading_and_error_message(cx, scope);
         }
@@ -123,6 +120,10 @@ impl WidgetMatchEvent for ModelList {
         let portal_list = self.portal_list(id!(list));
 
         for action in actions.iter() {
+            if let Some(_) = action.downcast_ref::<SearchAction>() {
+                self.loading_delay = cx.start_timeout(0.2);
+            }
+
             match action.cast() {
                 StoreAction::Search(_) | StoreAction::ResetSearch => {
                     self.view(id!(search_error)).set_visible(false);

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -2,7 +2,7 @@ use makepad_code_editor::code_view::CodeViewWidgetExt;
 use makepad_widgets::*;
 
 use crate::data::{
-    chats::model_loader::{ModelLoaderAction, ModelLoaderStatus},
+    chats::model_loader::{ModelLoaderStatus, ModelLoaderStatusChanged},
     store::Store,
 };
 
@@ -260,7 +260,7 @@ impl WidgetMatchEvent for SettingsScreen {
 
         for action in actions {
             // Once the modals are reloaded, let's clear the override port
-            if let Some(_) = action.downcast_ref::<ModelLoaderAction>() {
+            if let Some(_) = action.downcast_ref::<ModelLoaderStatusChanged>() {
                 if store.chats.model_loader.is_loaded() {
                     self.override_port = None;
                 }

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -1,7 +1,10 @@
 use makepad_code_editor::code_view::CodeViewWidgetExt;
 use makepad_widgets::*;
 
-use crate::data::{chats::model_loader::ModelLoaderStatus, store::Store};
+use crate::data::{
+    chats::model_loader::{ModelLoaderAction, ModelLoaderStatus},
+    store::Store,
+};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -53,7 +56,7 @@ live_design! {
                     text: "Local inference options will appear once you have a model loaded."
                 }
             }
-            
+
 
             main = <View> {
                 width: Fill, height: Fill
@@ -192,20 +195,6 @@ impl Widget for SettingsScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
-
-        // Once the modals are reloaded, let's clear the override port
-        if let Event::Signal = event {
-            // TODO: Use cx.action to send a more specific message, otherwise it could be refreshing all the time
-            let store = scope.data.get_mut::<Store>().unwrap();
-            if store.chats.model_loader.is_loaded() {
-                self.override_port = None;
-            }
-            if store.chats.model_loader.is_failed() {
-                self.view(id!(load_error_label)).set_visible(true);
-            } else {
-                self.view(id!(load_error_label)).set_visible(false);
-            }
-        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
@@ -268,6 +257,21 @@ curl http://localhost:{}/v1/chat/completions \\
 impl WidgetMatchEvent for SettingsScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let store = scope.data.get_mut::<Store>().unwrap();
+
+        for action in actions {
+            // Once the modals are reloaded, let's clear the override port
+            if let Some(_) = action.downcast_ref::<ModelLoaderAction>() {
+                if store.chats.model_loader.is_loaded() {
+                    self.override_port = None;
+                }
+                if store.chats.model_loader.is_failed() {
+                    self.view(id!(load_error_label)).set_visible(true);
+                } else {
+                    self.view(id!(load_error_label)).set_visible(false);
+                }
+            }
+        }
+
         let port_number_input = self.view.text_input(id!(port_number_input));
 
         if self.button(id!(edit_port_number)).clicked(actions) {


### PR DESCRIPTION
# Changes
- Replaced `Event::Signal` pattern matchings with reactions to specific cross-thread actions.
- Replaced `SignalToUI::set_ui_signal()` with `Cx::post_action(...)`.
- Replaced "polling" in the store when a signal comes, with normal action handling and routing.