### PR TITLE
make download_items responsive

### DIFF
--- a/src/landing/download_item.rs
+++ b/src/landing/download_item.rs
@@ -72,7 +72,7 @@ live_design! {
     }
 
     Progress = <View> {
-        width: 600,
+        width: Fill,
         height: Fit,
         spacing: 8,
 
@@ -197,9 +197,23 @@ live_design! {
             color: #fff,
         }
 
-        <Information> {}
-        <Progress> {}
-        <Actions> {}
+        <View> {
+            width: Fill,
+            height: Fit,
+            <Information> {}
+        }
+
+        <View> {
+            width: Fill,
+            height: Fit,
+            <Progress> {}
+        }
+
+        <View> {
+            width: Fill,
+            height: Fit,
+            <Actions> {}
+        }
     }
 }
 


### PR DESCRIPTION
Now, the layout in `download_items` is responsive.
![截图 2024-11-18 16-14-41](https://github.com/user-attachments/assets/d5d140de-9893-4e70-a479-5df63c339a8c)
