### PR TITLE
Fix chat switching

### DIFF
--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -1,4 +1,4 @@
-use super::chat_history_card::{ChatHistoryCardAction, ChatHistoryCardWidgetRefExt};
+use super::chat_history_card::ChatHistoryCardWidgetRefExt;
 use crate::chat::entity_button::EntityButtonWidgetRefExt;
 use crate::data::chats::chat::ChatID;
 use crate::data::store::Store;
@@ -185,10 +185,6 @@ impl WidgetMatchEvent for ChatHistory {
 
         if self.button(id!(new_chat_button)).clicked(&actions) {
             store.chats.create_empty_chat();
-
-            // Make sure text input is focused and other necessary setup happens.
-            cx.action(ChatHistoryCardAction::ChatSelected);
-
             self.redraw(cx);
         }
     }

--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -413,7 +413,6 @@ impl WidgetMatchEvent for ChatHistoryCard {
 
         if let Some(fe) = self.view(id!(content)).finger_down(actions) {
             if fe.tap_count == 1 {
-                cx.action(ChatHistoryCardAction::ChatSelected);
                 let store = scope.data.get_mut::<Store>().unwrap();
                 store.chats.set_current_chat(self.chat_id);
                 self.redraw(cx);
@@ -578,7 +577,6 @@ impl ChatHistoryCardRef {
 #[derive(Clone, DefaultNone, Eq, Hash, PartialEq, Debug)]
 pub enum ChatHistoryCardAction {
     None,
-    ChatSelected,
     ActivateTitleEdition(ChatID),
     MenuClosed(ChatID),
     DeleteChatOptionSelected(ChatID),

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 
 use super::{
-    chat_history_card::ChatHistoryCardAction, model_selector_list::ModelSelectorListAction,
-    prompt_input::PromptInputWidgetExt, shared::ChatAgentAvatarWidgetRefExt,
+    model_selector_list::ModelSelectorListAction, prompt_input::PromptInputWidgetExt,
+    shared::ChatAgentAvatarWidgetRefExt,
 };
 
 live_design! {

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -494,12 +494,6 @@ impl WidgetMatchEvent for ChatPanel {
         }
 
         for action in actions.iter() {
-            if let ChatHistoryCardAction::ChatSelected = action.cast() {
-                self.reset_scroll_messages(&store);
-                self.focus_on_prompt_input_pending = true;
-                self.redraw(cx);
-            }
-
             if let ModelSelectorListAction::AddedOrDeletedModel = action.cast() {
                 self.redraw(cx);
             }

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -521,7 +521,7 @@ impl WidgetMatchEvent for ChatPanel {
                 }
                 ChatLineAction::Edit(id, updated, regenerate) => {
                     if regenerate {
-                        self.send_message(cx, store, updated, Some(id));
+                        self.send_message(cx, scope, updated, Some(id));
                         return;
                     } else {
                         store.edit_chat_message(id, updated);
@@ -745,20 +745,18 @@ impl ChatPanel {
             .button(id!(main_prompt_input.prompt_send_button))
             .clicked(&actions)
         {
-            let store = scope.data.get_mut::<Store>().unwrap();
-            self.send_message(cx, store, prompt_input.text(), None);
+            self.send_message(cx, scope, prompt_input.text(), None);
         }
 
         if let Some(prompt) = prompt_input.returned(actions) {
-            let store = scope.data.get_mut::<Store>().unwrap();
-            self.send_message(cx, store, prompt, None);
+            self.send_message(cx, scope, prompt, None);
         }
     }
 
     fn send_message(
         &mut self,
         cx: &mut Cx,
-        store: &mut Store,
+        scope: &mut Scope,
         prompt: String,
         regenerate_from: Option<usize>,
     ) {
@@ -768,7 +766,7 @@ impl ChatPanel {
         }
 
         // Let's confirm we're in an appropriate state to send a message
-        // self.update_state(store);
+        self.update_state(scope);
         if matches!(
             self.state,
             State::ModelSelectedWithChat {
@@ -778,6 +776,8 @@ impl ChatPanel {
                 ..
             } | State::ModelSelectedWithEmptyChat { is_loading: false }
         ) {
+            let store = scope.data.get_mut::<Store>().unwrap();
+
             if let Some(entity_selected) = &self
                 .prompt_input(id!(main_prompt_input))
                 .borrow()


### PR DESCRIPTION
# Initial problem

I noticed that when switching from a long chat to a new agent chat, portal list bugs due to scroll reset not being triggered. Some dev commits ago this caused the app to crash but now it just causes a visual and performance issue.

# Deeper problem

Actually, this issue can be provoked by mixing other kinds of user interaction:
- If you are in a long chat, then you go to "My Models" and then you start a new chat with the same model from there.
- If you have 2 chats, one long and one short, and being at the long one you delete it.

And there may be more I'm not noticing now. Or at least, there will be more. 

# Solution

- Do not try to react to every possible action that my update current chat id.
- Instead, directly react to the chat id change itself :)

There are two ways to do this without a reactivity abstraction:
- Track chat id in a widget local field and compare it to determine if it changed.
  - This is the same approach that was used for `chat_params.rs`.
  - And is the approach I'm currently proposing in this PR due to it's simplicity and being proven to work somewhere else. 
- Alternatively, dispatch a specific global action from `set_current_chat` itself like `CurrentChatIdChanged` using `Cx::post_action`.

No matter the approach,  `ChatHistoryCardAction::ChatSelected` becomes unnecessary and can be safely deleted. 
