### PR TITLE
Fix chat switch streaming cancel

### DIFF
--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -414,7 +414,7 @@ impl WidgetMatchEvent for ChatHistoryCard {
         if let Some(fe) = self.view(id!(content)).finger_down(actions) {
             if fe.tap_count == 1 {
                 let store = scope.data.get_mut::<Store>().unwrap();
-                store.chats.set_current_chat(self.chat_id);
+                store.chats.set_current_chat(Some(self.chat_id));
                 self.redraw(cx);
             }
         }

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -210,7 +210,6 @@ impl Chats {
 
     pub fn remove_chat(&mut self, chat_id: ChatID) {
         if self.current_chat_id == Some(chat_id) {
-            self.cancel_chat_streaming();
             self.set_current_chat(self.get_last_selected_chat_id());
         }
 

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -209,16 +209,19 @@ impl Chats {
     }
 
     pub fn remove_chat(&mut self, chat_id: ChatID) {
-        if let Some(chat) = self.saved_chats.iter().find(|c| c.borrow().id == chat_id) {
-            chat.borrow().remove_saved_file();
-        };
-        self.saved_chats.retain(|c| c.borrow().id != chat_id);
-
-        if let Some(current_chat_id) = self.current_chat_id {
-            if current_chat_id == chat_id {
-                self.set_current_chat(self.get_last_selected_chat_id());
-            }
+        if self.current_chat_id == Some(chat_id) {
+            self.cancel_chat_streaming();
+            self.set_current_chat(self.get_last_selected_chat_id());
         }
+
+        let pos = self
+            .saved_chats
+            .iter()
+            .position(|c| c.borrow().id == chat_id)
+            .expect("non-existing chat");
+
+        let chat = self.saved_chats.remove(pos);
+        chat.borrow().remove_saved_file();
     }
 
     pub fn handle_action(&mut self, action: &Box<dyn ActionTrait>) {

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -364,7 +364,7 @@ impl Store {
 
     fn init_current_chat(&mut self) {
         if let Some(chat_id) = self.chats.get_last_selected_chat_id() {
-            self.chats.set_current_chat(chat_id);
+            self.chats.set_current_chat(Some(chat_id));
         } else {
             self.chats.create_empty_chat();
         }


### PR DESCRIPTION
# Problem

When switching to a different chat from one that was streaming, it will not always cancel the previous streaming causing issues in the UI.

Some examples of cancellation not happening are when creating a new chat or when deleting the streaming chat.
