### PR TITLE
Update backend wasm to support `moxin-chat-7b`

### DIFF
--- a/moly-backend/src/backend_impls/api_server.rs
+++ b/moly-backend/src/backend_impls/api_server.rs
@@ -138,6 +138,13 @@ pub fn run_wasm_by_downloaded_file(
     let mut wasi_nn = wasmedge_sdk::plugin::PluginManager::load_plugin_wasi_nn().unwrap();
     instances.insert(wasi_nn.name().unwrap(), &mut wasi_nn);
 
+    let mut wasi_logger = wasmedge_sdk::plugin::PluginManager::create_plugin_instance(
+        "wasi_logging",
+        "wasi:logging/logging",
+    )
+    .unwrap();
+    instances.insert(wasi_logger.name().unwrap(), &mut wasi_logger);
+
     let store = Store::new(None, instances).unwrap();
     let mut vm = Vm::new(store);
     vm.register_module(None, wasm_module.clone()).unwrap();
@@ -261,7 +268,7 @@ impl BackendModel for LLamaEdgeApiServer {
         });
 
         let mut test_server = false;
-        for _i in 0..5 {
+        for _i in 0..20 {
             let r = reqwest::blocking::ClientBuilder::new()
                 .timeout(Duration::from_secs(3))
                 .no_proxy()
@@ -275,7 +282,7 @@ impl BackendModel for LLamaEdgeApiServer {
                     break;
                 }
             }
-            let _ = std::thread::sleep(std::time::Duration::from_secs(1));
+            let _ = std::thread::sleep(std::time::Duration::from_secs(3));
         }
         if test_server {
             let _ = tx.send(Ok(moly_protocol::protocol::LoadModelResponse::Completed(


### PR DESCRIPTION
* Update wasm to support `moxin-chat-7b`
* Load wasi_logger. Since `wasmedge 0.14.1`, `wasi_logger` has been a built-in plugin for `wasmedge`.