### PR TITLE
Fix redraw loop

### DIFF
--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -3,7 +3,7 @@ use crate::{
         chats::{chat::ChatID, chat_entity::ChatEntityId},
         store::Store,
     },
-    shared::{modal::ModalWidgetExt, utils::human_readable_name},
+    shared::{actions::ChatAction, modal::ModalWidgetExt, utils::human_readable_name},
 };
 
 use makepad_widgets::*;
@@ -429,6 +429,12 @@ impl WidgetMatchEvent for ChatHistoryCard {
                     | DeleteChatModalAction::ChatDeleted
             ) {
                 self.modal(id!(delete_chat_modal)).close(cx);
+            }
+
+            if let ChatAction::TitleUpdated(chat_id) = action.cast() {
+                if self.chat_id == chat_id {
+                    self.redraw(cx);
+                }
             }
         }
     }

--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -350,7 +350,7 @@ impl Widget for ChatHistoryCard {
             chat.borrow_mut().get_title(),
             &caption.clone().unwrap_or_default(),
         );
-        self.update_title_visibility(cx);
+        self.update_title_visibility();
 
         let initial_letter = caption
             .unwrap_or("A".to_string())
@@ -451,7 +451,7 @@ impl ChatHistoryCard {
             .set_text(&human_readable_name(caption));
     }
 
-    fn update_title_visibility(&mut self, cx: &mut Cx) {
+    fn update_title_visibility(&mut self) {
         let on_edit = matches!(self.title_edition_state, TitleState::OnEdit);
         self.view(id!(edit_buttons)).set_visible(on_edit);
         self.view(id!(title_input_container)).set_visible(on_edit);
@@ -459,8 +459,6 @@ impl ChatHistoryCard {
 
         let editable = matches!(self.title_edition_state, TitleState::Editable);
         self.view(id!(title_label_container)).set_visible(editable);
-
-        self.redraw(cx);
     }
 
     fn transition_title_state(&mut self, cx: &mut Cx) {
@@ -469,7 +467,8 @@ impl ChatHistoryCard {
             TitleState::Editable => TitleState::OnEdit,
         };
 
-        self.update_title_visibility(cx);
+        self.update_title_visibility();
+        self.redraw(cx);
 
         match self.title_edition_state {
             TitleState::OnEdit => {

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -769,34 +769,49 @@ impl ChatPanel {
 
         // Let's confirm we're in an appropriate state to send a message
         self.update_state(scope);
-        if matches!(
-            self.state,
+
+        match self.state {
             State::ModelSelectedWithChat {
                 receiving_response: false,
                 was_cancelled: false,
                 is_loading: false,
                 ..
-            } | State::ModelSelectedWithEmptyChat { is_loading: false }
-        ) {
-            let store = scope.data.get_mut::<Store>().unwrap();
-
-            if let Some(entity_selected) = &self
-                .prompt_input(id!(main_prompt_input))
-                .borrow()
-                .unwrap()
-                .entity_selected
-            {
-                store.send_entity_message(entity_selected, prompt, regenerate_from);
-            } else {
-                store.send_message_to_current_entity(prompt, regenerate_from);
+            } => {
+                self.send_message_aux(cx, scope, prompt, regenerate_from);
             }
-
-            self.prompt_input(id!(main_prompt_input)).reset_text(false);
-
-            // Scroll to the bottom when the message is sent
-            self.scroll_messages_to_bottom(cx);
-            self.redraw(cx);
+            State::ModelSelectedWithEmptyChat { is_loading: false } => {
+                self.send_message_aux(cx, scope, prompt, regenerate_from);
+                cx.action(ChatAction::TitleUpdated(self.current_chat_id.unwrap()));
+            }
+            _ => {}
         }
+    }
+
+    fn send_message_aux(
+        &mut self,
+        cx: &mut Cx,
+        scope: &mut Scope,
+        prompt: String,
+        regenerate_from: Option<usize>,
+    ) {
+        let store = scope.data.get_mut::<Store>().unwrap();
+
+        if let Some(entity_selected) = &self
+            .prompt_input(id!(main_prompt_input))
+            .borrow()
+            .unwrap()
+            .entity_selected
+        {
+            store.send_entity_message(entity_selected, prompt, regenerate_from);
+        } else {
+            store.send_message_to_current_entity(prompt, regenerate_from);
+        }
+
+        self.prompt_input(id!(main_prompt_input)).reset_text(false);
+
+        // Scroll to the bottom when the message is sent
+        self.scroll_messages_to_bottom(cx);
+        self.redraw(cx);
     }
 
     fn update_view(&mut self, cx: &mut Cx2d, scope: &mut Scope) {

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -693,7 +693,6 @@ impl ChatPanel {
                     },
                 );
                 stop_button.set_visible(false);
-                stop_button.redraw(cx);
             }
             PromptInputButton::EnabledStop => {
                 stop_button.set_visible(true);

--- a/src/shared/actions.rs
+++ b/src/shared/actions.rs
@@ -1,11 +1,12 @@
 use makepad_widgets::{ActionDefaultRef, DefaultNone};
 use moly_protocol::data::FileID;
 
-use crate::data::chats::chat_entity::ChatEntityId;
+use crate::data::chats::{chat::ChatID, chat_entity::ChatEntityId};
 
 #[derive(Clone, DefaultNone, Debug)]
 pub enum ChatAction {
     Start(ChatEntityId),
+    TitleUpdated(ChatID),
     None,
 }
 


### PR DESCRIPTION
# Changes
- Remove a `self.redraw(cx)` that was indirectly being used inside `ChatHistoryCard`'s `draw_walk` causing a loop.
- Explicitly redraw `ChatHistoryCard` on title update, whose reaction was depending on the loop bug.
- Remove a `self.redraw(cx)` that was indirectly being used inside `ChatPanel`'s `draw_walk`, but only when the stop button styles are updated (after sending a message).

# Testing

I played with the app while keeping an eye on the process CPU and GPU usage. Also added the following to `ChatPanel`'s `draw_walk` to control that flow is not in a loop.

```rust
eprintln!(
    "ChatPanel::draw_walk ({})",
    std::time::SystemTime::now()
        .duration_since(std::time::UNIX_EPOCH)
        .unwrap()
        .as_millis()
);
```

# Links

Closes #329 