### PR TITLE
Fix the incompatibility issue of libwasmedge.0.dylib on macos x86_64

### DIFF
--- a/packaging/before-packaging-command/src/main.rs
+++ b/packaging/before-packaging-command/src/main.rs
@@ -171,13 +171,21 @@ fn download_wasmedge_macos(version: &str) -> std::io::Result<()> {
     // Command 1: Create the destination directory.
     let dest_dir = std::env::current_dir()?.join("wasmedge");
     fs::create_dir_all(&dest_dir)?;
-
+    let mut wasmedge_download_url = String::new();
+    let mut wasi_nn_download_url = String::new();
+    if std::env::consts::ARCH == "x86_64" {
+        wasmedge_download_url = format!("https://github.com/WasmEdge/WasmEdge/releases/download/{}/WasmEdge-{}-darwin_x86_64.tar.gz", version, version);
+        wasi_nn_download_url = format!("https://github.com/WasmEdge/WasmEdge/releases/download/{}/WasmEdge-plugin-wasi_nn-ggml-{}-darwin_x86_64.tar.gz", version, version);
+    } else {
+        wasmedge_download_url = format!("https://github.com/WasmEdge/WasmEdge/releases/download/{version}/WasmEdge-{version}-darwin_arm64.tar.gz");
+        wasi_nn_download_url = format!("https://github.com/WasmEdge/WasmEdge/releases/download/{version}/WasmEdge-plugin-wasi_nn-ggml-{version}-darwin_arm64.tar.gz");
+    }
     // Command 2: Download and extract WasmEdge.
     {
         println!("Downloading wasmedge v{version} to: {}", dest_dir.display());
         let curl_script_cmd = Command::new("curl")
             .arg("-sSfL")
-            .arg("https://github.com/WasmEdge/WasmEdge/releases/download/0.14.0/WasmEdge-0.14.0-darwin_arm64.tar.gz")
+            .arg(wasmedge_download_url)
             .stdout(Stdio::piped())
             .spawn()?;
 
@@ -209,7 +217,7 @@ fn download_wasmedge_macos(version: &str) -> std::io::Result<()> {
         println!("Downloading wasmedge v{version} WASI-NN plugin to: {}", plugin_dest_dir.display());
         let curl_script_cmd = Command::new("curl")
             .arg("-sSfL")
-            .arg("https://github.com/WasmEdge/WasmEdge/releases/download/0.14.0/WasmEdge-plugin-wasi_nn-ggml-0.14.0-darwin_arm64.tar.gz")
+            .arg(wasi_nn_download_url)
             .stdout(Stdio::piped())
             .spawn()?;
 

--- a/packaging/before-packaging-command/src/main.rs
+++ b/packaging/before-packaging-command/src/main.rs
@@ -65,7 +65,6 @@ fn main() -> std::io::Result<()> {
     let mut is_before_packaging = false;
     let mut is_before_each_package = false;
     let mut host_os_opt: Option<String> = None;
-    let mut arch_opt: Option<String> = None;
 
     let mut args = std::env::args().peekable();
     while let Some(arg) = args.next() {
@@ -83,21 +82,12 @@ fn main() -> std::io::Result<()> {
                 .map(|s| s.to_string())
                 .or_else(|| args.peek().map(|s| s.to_string()));
         }
-        if arch_opt.is_none() && (arg.contains("arch"))
-        {
-            arch_opt = arg
-                .split("=")
-                .last()
-                .map(|s| s.to_string())
-                .or_else(|| args.peek().map(|s| s.to_string()));
-        }
     }
 
     let host_os = host_os_opt.as_deref().unwrap_or(std::env::consts::OS);
-    let arch = arch_opt.as_deref().unwrap_or(std::env::consts::ARCH);
 
     match (is_before_packaging, is_before_each_package) {
-        (true, false) => before_packaging(host_os, arch),
+        (true, false) => before_packaging(host_os),
         (false, true) => before_each_package(host_os),
         (true, true) => panic!("Cannot run both 'before-packaging' and 'before-each-package' commands at the same time."),
         (false, false) => panic!("Please specify either the 'before-packaging' or 'before-each-package' command."),
@@ -113,7 +103,7 @@ fn main() -> std::io::Result<()> {
 ///    The location of the `makepad-widgets` crate is determined using `cargo-metadata`.
 /// 3. Recursively copies the Moly-specific `./resources` directory to `./dist/resources/moly/`.
 /// 4. (If macOS) Downloads WasmEdge and sets up the plugins into the `./wasmedge/` directory.
-fn before_packaging(host_os: &str, arch: &str) -> std::io::Result<()> {
+fn before_packaging(host_os: &str) -> std::io::Result<()> {
     let cwd = std::env::current_dir()?;
     let dist_resources_dir = cwd.join("dist").join("resources");
     fs::create_dir_all(&dist_resources_dir)?;
@@ -161,7 +151,7 @@ fn before_packaging(host_os: &str, arch: &str) -> std::io::Result<()> {
     println!("  --> Done!");
 
     if host_os == "macos" {
-       download_wasmedge_macos("0.14.0", arch)?;
+       download_wasmedge_macos("0.14.0")?;
     }
 
     Ok(())
@@ -177,17 +167,24 @@ fn before_packaging(host_os: &str, arch: &str) -> std::io::Result<()> {
 ///    && mkdir -p ./wasmedge/WasmEdge-0.14.0-Darwin/plugin \
 ///    && curl -sf --location --progress-bar --show-error https://github.com/WasmEdge/WasmEdge/releases/download/0.14.0/WasmEdge-plugin-wasi_nn-ggml-0.14.0-darwin_arm64.tar.gz | bsdtar -xf- -C ./wasmedge/WasmEdge-0.14.0-Darwin/plugin; \
 /// ```
-fn download_wasmedge_macos(version: &str, arch: &str) -> std::io::Result<()> {
+fn download_wasmedge_macos(version: &str) -> std::io::Result<()> {
     // Command 1: Create the destination directory.
     let dest_dir = std::env::current_dir()?.join("wasmedge");
     fs::create_dir_all(&dest_dir)?;
-    let (wasmedge_download_url, wasi_nn_download_url) = if arch == "x86_64" {
-        (format!("https://github.com/WasmEdge/WasmEdge/releases/download/{}/WasmEdge-{}-darwin_x86_64.tar.gz", version, version),
-        format!("https://github.com/WasmEdge/WasmEdge/releases/download/{}/WasmEdge-plugin-wasi_nn-ggml-{}-darwin_x86_64.tar.gz", version, version))
-    } else {
-        (format!("https://github.com/WasmEdge/WasmEdge/releases/download/{version}/WasmEdge-{version}-darwin_arm64.tar.gz"),
-        format!("https://github.com/WasmEdge/WasmEdge/releases/download/{version}/WasmEdge-plugin-wasi_nn-ggml-{version}-darwin_arm64.tar.gz"))
-    };
+    #[cfg(target_arch = "x86_64")]
+    let suffix = "x86_64";
+    #[cfg(target_arch = "aarch64")]
+    let suffix = "arm64";
+    let (wasmedge_download_url, wasi_nn_download_url) = (
+    format!(
+        "https://github.com/WasmEdge/WasmEdge/releases/download/{}/WasmEdge-{}-darwin_{}.tar.gz",
+        version, version, suffix
+    ),
+    format!(
+        "https://github.com/WasmEdge/WasmEdge/releases/download/{}/WasmEdge-plugin-wasi_nn-ggml-{}-darwin_{}.tar.gz",
+        version, version, suffix
+    ),
+    );
     // Command 2: Download and extract WasmEdge.
     {
         println!("Downloading wasmedge v{version} to: {}", dest_dir.display());


### PR DESCRIPTION
## Fix the crash on macos x86_64
```shell
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               _moly_app [22638]
Path:                  /Applications/Moly.app/Contents/MacOS/_moly_app
Identifier:            _moly_app
Version:               ???
Code Type:             X86-64 (Native)
Parent Process:        Exited process [22637]
User ID:               501

Date/Time:             2024-12-31 11:29:13.7184 +0800
OS Version:            macOS 14.4.1 (23E224)
Report Version:        12
Bridge OS Version:     8.4 (21P4222)
Anonymous UUID:        38FD8E42-55B9-6552-B62A-10C3E31EE872

Sleep/Wake UUID:       A0EBF6FF-3DDF-4AB0-AF3A-BAF66E8CF9F7

Time Awake Since Boot: 990000 seconds
Time Since Wake:       11252 seconds

System Integrity Protection: disabled

Crashed Thread:        0

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000

Termination Reason:    Namespace DYLD, Code 1 Library missing
Library not loaded: @rpath/libwasmedge.0.dylib
Referenced from: <EE478A10-7904-3190-B4B7-50975A5D71B1> /Applications/Moly.app/Contents/MacOS/_moly_app
Reason: tried: '/Applications/Moly.app/Contents/Frameworks/libwasmedge.0.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64h' or 'x86_64')), '/Applications/Moly.app/Contents/Frameworks/libwasmedge.0.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64h' or 'x86_64'))
(terminated at launch; ignore backtrace)

Thread 0 Crashed:
0   dyld                          	    0x7ff8196c9b3e __abort_with_payload + 10
1   dyld                          	    0x7ff8196e2bb7 abort_with_payload_wrapper_internal + 82
2   dyld                          	    0x7ff8196e2be9 abort_with_payload + 9
3   dyld                          	    0x7ff81966f2e5 dyld4::halt(char const*, dyld4::StructuredError const*) + 335
4   dyld                          	    0x7ff81966c4e2 dyld4::prepare(dyld4::APIs&, dyld3::MachOAnalyzer const*) + 4099
5   dyld                          	    0x7ff81966b2ff start + 1839


Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x0000000002000209  rbx: 0x0000000000000001  rcx: 0x00007ff7bfbd9578  rdx: 0x00007ff7bfbd99e0
  rdi: 0x0000000000000006  rsi: 0x0000000000000001  rbp: 0x00007ff7bfbd95c0  rsp: 0x00007ff7bfbd9578
   r8: 0x00007ff7bfbd95e0   r9: 0x0000000000000000  r10: 0x000000000000005f  r11: 0x0000000000000246
  r12: 0x0000000000000000  r13: 0x00007ff7bfbd99e0  r14: 0x0000000000000006  r15: 0x000000000000005f
  rip: 0x00007ff8196c9b3e  rfl: 0x0000000000000246  cr2: 0x0000000000000000
  
Logical CPU:     0
Error Code:      0x02000209 
Trap Number:     133
```