### PR TITLE
Update wasmedge version to 0.14.1

### DIFF
--- a/packaging/before-packaging-command/src/main.rs
+++ b/packaging/before-packaging-command/src/main.rs
@@ -151,7 +151,7 @@ fn before_packaging(host_os: &str) -> std::io::Result<()> {
     println!("  --> Done!");
 
     if host_os == "macos" {
-       download_wasmedge_macos("0.14.0")?;
+       download_wasmedge_macos("0.14.1")?;
     }
 
     Ok(())


### PR DESCRIPTION
This [pr](https://github.com/moxin-org/moly/pull/330)  requires the wasi-logger plugin which is built into wasmedge 0.14.1.
And wasi-logger in wasmedge 0.14.0 has bug.

So we need update wasmedge to 0.14.1