### PR TITLE
update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "makepad-code-editor"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-widgets",
 ]
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1528,17 +1528,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1557,7 +1557,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1601,17 +1601,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1628,12 +1628,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -3147,7 +3147,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
+source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
 
 [[package]]
 name = "typenum"


### PR DESCRIPTION
I think we can update the `lock` file regularly, like every week or two, to match the latest `rik` branch.