### PR TITLE
fix(Expand-Archive): import it from Microsoft.PowerShell.Archive module

### DIFF
--- a/moly-runner/src/main.rs
+++ b/moly-runner/src/main.rs
@@ -434,10 +434,10 @@ fn install_wasmedge<P: AsRef<Path>>(install_path_ref: P) -> Result<PathBuf, std:
         r#"
         $ProgressPreference = 'SilentlyContinue' ## makes downloads much faster
         Invoke-WebRequest -Uri "{WASMEDGE_0_14_0_WINDOWS_URL}" -OutFile "$env:TEMP\WasmEdge-0.14.0-windows.zip"
-        Expand-Archive -Force -Path "$env:TEMP\WasmEdge-0.14.0-windows.zip" -DestinationPath "{}"
+        Microsoft.PowerShell.Archive\Expand-Archive -Force -Path "$env:TEMP\WasmEdge-0.14.0-windows.zip" -DestinationPath "{}"
 
         Invoke-WebRequest -Uri "{wasi_nn_plugin_url}" -OutFile "$env:TEMP\{wasi_nn_dir_name}.zip"
-        Expand-Archive -Force -Path "$env:TEMP\{wasi_nn_dir_name}.zip" -DestinationPath "$env:TEMP\{wasi_nn_dir_name}"
+        Microsoft.PowerShell.Archive\Expand-Archive -Force -Path "$env:TEMP\{wasi_nn_dir_name}.zip" -DestinationPath "$env:TEMP\{wasi_nn_dir_name}"
         Copy-Item -Recurse -Force -Path "$env:TEMP\{wasi_nn_dir_name}\{wasi_nn_dir_name}\lib\wasmedge" -Destination "{}"
         $ProgressPreference = 'Continue' ## restore default progress bars
         "#,


### PR DESCRIPTION
For PowerShell 5.1, Expand-Archive default from Pscx module use -OutputPath instead of -DestinationPath parameter.

```
Downloading WasmEdge 0.14.0 from GitHub; installing to C:\Users\Administrator\AppData\Roaming\moxin-org\moly\data\WasmEdge-0.14.0-Windows
 --> Using WASI-NN plugin at: https://github.com/second-state/WASI-NN-GGML-PLUGIN-REGISTRY/releases/download/b3499/WasmEdge-plugin-wasi_nn-ggml
-noavx-0.14.0-windows_x86_64.zip
Successfully installed wasmedge to: C:\Users\Administrator\AppData\Roaming\moxin-org\moly\data\WasmEdge-0.14.0-Windows
thread 'main' panicked at moly-runner\src\main.rs:242:10:
failed to find or install wasmedge dylibs
```

Also see: https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/52

---

It's odd that the result of powershell_script run is Ok (i.e. output.success() is true) for the whole ps script. I wrote a unit test using `Expand-Archive` with `-DestinationPath`, the result is Err and the same InvalidArgument output as I saw from the ps prompt.