### PR TITLE
Bump Makepad version - update set_visible and set_text usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "makepad-code-editor"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-widgets",
 ]
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1528,17 +1528,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1557,7 +1557,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1601,17 +1601,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1628,13 +1628,14 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
+ "bitflags 2.6.0",
  "hilog-sys",
  "makepad-android-state",
  "makepad-futures",
@@ -1656,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1671,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1679,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -1688,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1697,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -1711,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -3147,7 +3148,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#77fbf5fc3c56f435aa2cd887a3f815fdd29c149b"
+source = "git+https://github.com/makepad/makepad?branch=rik#5fe385104b071924c664ea9c06ce114c14b796f9"
 
 [[package]]
 name = "typenum"

--- a/src/app.rs
+++ b/src/app.rs
@@ -297,7 +297,7 @@ impl App {
 
             match notification {
                 DownloadPendingNotification::DownloadedFile(file) => {
-                    popup.set_data(&file, DownloadResult::Success);
+                    popup.set_data(cx, &file, DownloadResult::Success);
                     cx.action(ModelSelectorListAction::AddedOrDeletedModel);
                 }
                 DownloadPendingNotification::DownloadErrored(file) => {
@@ -315,20 +315,20 @@ impl App {
             0 => {
                 self.timer = cx.start_timeout(15.0);
                 self.download_retry_attempts += 1;
-                popup.set_retry_data();
+                popup.set_retry_data(cx);
             },
             1 => {
                 self.timer = cx.start_timeout(30.0);
                 self.download_retry_attempts += 1;
-                popup.set_retry_data();
+                popup.set_retry_data(cx);
             },
             2 => {
                 self.timer = cx.start_timeout(60.0);
                 self.download_retry_attempts += 1;
-                popup.set_retry_data();
+                popup.set_retry_data(cx);
             },
             _ => {
-                popup.set_data(&file, DownloadResult::Failure);
+                popup.set_data(cx, &file, DownloadResult::Failure);
                 self.download_retry_attempts = 0;
             }
         }

--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -169,12 +169,12 @@ impl Widget for ChatHistory {
                         }
                         Item::NoAgentsWarning(text) => {
                             let item = list.item(cx, item_id, live_id!(NoAgentsWarning));
-                            item.set_text(text);
+                            item.set_text(cx,text);
                             item.draw_all(cx, scope);
                         }
                         Item::AgentButton(agent) => {
                             let item = list.item(cx, item_id, live_id!(Agent));
-                            item.as_entity_button().set_agent(agent);
+                            item.as_entity_button().set_agent(cx, agent);
                             item.draw_all(cx, scope);
                         }
                         Item::ChatButton(chat_id) => {

--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -347,10 +347,11 @@ impl Widget for ChatHistoryCard {
 
         let caption = store.get_chat_entity_name(self.chat_id);
         self.set_title_text(
+            cx,
             chat.borrow_mut().get_title(),
             &caption.clone().unwrap_or_default(),
         );
-        self.update_title_visibility();
+        self.update_title_visibility(cx);
 
         let initial_letter = caption
             .unwrap_or("A".to_string())
@@ -364,17 +365,17 @@ impl Widget for ChatHistoryCard {
             Some(ChatEntityId::Agent(agent_id)) => {
                 let agent = store.chats.get_agent_or_placeholder(&agent_id);
 
-                self.view(id!(avatar_section.model)).set_visible(false);
+                self.view(id!(avatar_section.model)).set_visible(cx, false);
                 self.chat_agent_avatar(id!(avatar_section.agent))
                     .set_visible(true);
                 self.chat_agent_avatar(id!(avatar_section.agent))
                     .set_agent(agent);
             }
             _ => {
-                self.view(id!(avatar_section.model)).set_visible(true);
+                self.view(id!(avatar_section.model)).set_visible(cx, true);
                 self.chat_agent_avatar(id!(avatar_section.agent))
                     .set_visible(false);
-                self.view.label(id!(avatar_label)).set_text(&initial_letter);
+                self.view.label(id!(avatar_label)).set_text(cx, &initial_letter);
             }
         }
 
@@ -448,23 +449,23 @@ impl ChatHistoryCard {
         }
     }
 
-    fn set_title_text(&mut self, text: &str, caption: &str) {
-        self.view.label(id!(title_label)).set_text(text.trim());
+    fn set_title_text(&mut self, cx: &mut Cx, text: &str, caption: &str) {
+        self.view.label(id!(title_label)).set_text(cx,text.trim());
         if let TitleState::Editable = self.title_edition_state {
-            self.view.text_input(id!(title_input)).set_text(text.trim());
+            self.view.text_input(id!(title_input)).set_text(cx,text.trim());
         }
         self.label(id!(model_or_agent_name_label))
-            .set_text(&human_readable_name(caption));
+            .set_text(cx,&human_readable_name(caption));
     }
 
-    fn update_title_visibility(&mut self) {
+    fn update_title_visibility(&mut self, cx: &mut Cx) {
         let on_edit = matches!(self.title_edition_state, TitleState::OnEdit);
-        self.view(id!(edit_buttons)).set_visible(on_edit);
-        self.view(id!(title_input_container)).set_visible(on_edit);
-        self.button(id!(chat_options)).set_visible(!on_edit);
+        self.view(id!(edit_buttons)).set_visible(cx, on_edit);
+        self.view(id!(title_input_container)).set_visible(cx, on_edit);
+        self.button(id!(chat_options)).set_visible(cx, !on_edit);
 
         let editable = matches!(self.title_edition_state, TitleState::Editable);
-        self.view(id!(title_label_container)).set_visible(editable);
+        self.view(id!(title_label_container)).set_visible(cx, editable);
     }
 
     fn transition_title_state(&mut self, cx: &mut Cx) {
@@ -473,7 +474,7 @@ impl ChatHistoryCard {
             TitleState::Editable => TitleState::OnEdit,
         };
 
-        self.update_title_visibility();
+        self.update_title_visibility(cx);
         self.redraw(cx);
 
         match self.title_edition_state {

--- a/src/chat/chat_line.rs
+++ b/src/chat/chat_line.rs
@@ -302,7 +302,7 @@ impl Widget for ChatLine {
                 let hovered = self.view.area().rect(cx).contains(e.abs);
                 if self.hovered != hovered {
                     self.hovered = hovered;
-                    self.view(id!(actions_section.actions)).set_visible(hovered);
+                    self.view(id!(actions_section.actions)).set_visible(cx, hovered);
                     self.redraw(cx);
                 }
             }
@@ -332,23 +332,23 @@ impl ChatLine {
             ChatLineState::Editable
         };
 
-        self.view(id!(actions_section.actions)).set_visible(false);
-        self.view(id!(edit_buttons)).set_visible(enabled);
-        self.view(id!(input_container)).set_visible(enabled);
-        self.show_or_hide_message_label(!enabled);
+        self.view(id!(actions_section.actions)).set_visible(cx, false);
+        self.view(id!(edit_buttons)).set_visible(cx, enabled);
+        self.view(id!(input_container)).set_visible(cx, enabled);
+        self.show_or_hide_message_label(cx, !enabled);
 
         self.redraw(cx);
     }
 
-    pub fn show_or_hide_message_label(&mut self, show: bool) {
+    pub fn show_or_hide_message_label(&mut self, cx: &mut Cx, show: bool) {
         let text = self.text_input(id!(input)).text();
         let to_markdown = parse_markdown(&text);
         let is_plain_text = to_markdown.nodes.len() <= 3;
 
         self.view(id!(plain_text_message_container))
-            .set_visible(show && is_plain_text);
+            .set_visible(cx, show && is_plain_text);
         self.view(id!(markdown_message_container))
-            .set_visible(show && !is_plain_text);
+            .set_visible(cx, show && !is_plain_text);
     }
 
     pub fn handle_editable_actions(&mut self, cx: &mut Cx, actions: &Actions) {
@@ -409,27 +409,27 @@ impl ChatLine {
 }
 
 impl ChatLineRef {
-    pub fn set_sender_name(&mut self, text: &str) {
+    pub fn set_sender_name(&mut self, cx: &mut Cx, text: &str) {
         let Some(inner) = self.borrow_mut() else {
             return;
         };
-        inner.label(id!(sender_name)).set_text(text);
+        inner.label(id!(sender_name)).set_text(cx,text);
     }
 
-    pub fn set_model_avatar_text(&mut self, text: &str) {
+    pub fn set_model_avatar_text(&mut self, cx: &mut Cx, text: &str) {
         let Some(inner) = self.borrow_mut() else {
             return;
         };
-        inner.view(id!(avatar_section.model)).set_visible(true);
+        inner.view(id!(avatar_section.model)).set_visible(cx, true);
         inner.chat_agent_avatar(id!(avatar_section.agent)).set_visible(false);
-        inner.label(id!(avatar_label)).set_text(text);
+        inner.label(id!(avatar_label)).set_text(cx,text);
     }
 
-    pub fn set_model_avatar(&mut self, agent: &MofaAgent) {
+    pub fn set_model_avatar(&mut self, cx: &mut Cx, agent: &MofaAgent) {
         let Some(inner) = self.borrow_mut() else {
             return;
         };
-        inner.view(id!(avatar_section.model)).set_visible(false);
+        inner.view(id!(avatar_section.model)).set_visible(cx, false);
         inner.chat_agent_avatar(id!(avatar_section.agent)).set_visible(true);
         inner.chat_agent_avatar(id!(avatar_section.agent)).set_agent(agent);
     }
@@ -444,19 +444,19 @@ impl ChatLineRef {
             ChatLineState::Editable | ChatLineState::NotEditable => {
                 if is_streaming && !text.is_empty() {
                     let output = format!("{}{}", text, "●");
-                    inner.text_input(id!(input)).set_text(&output.trim());
-                    inner.label(id!(plain_text_message)).set_text(&output.trim());
-                    inner.markdown(id!(markdown_message)).set_text(&output.trim());
+                    inner.text_input(id!(input)).set_text(cx,&output.trim());
+                    inner.label(id!(plain_text_message)).set_text(cx,&output.trim());
+                    inner.markdown(id!(markdown_message)).set_text(cx,&output.trim());
                 } else {
-                    inner.text_input(id!(input)).set_text(text.trim());
-                    inner.label(id!(plain_text_message)).set_text(text.trim());
-                    inner.markdown(id!(markdown_message)).set_text(text.trim());
+                    inner.text_input(id!(input)).set_text(cx,text.trim());
+                    inner.label(id!(plain_text_message)).set_text(cx,text.trim());
+                    inner.markdown(id!(markdown_message)).set_text(cx,text.trim());
                 }
 
                 // We know only AI assistant messages could be empty, so it is never
                 // displayed in user's chat lines.
                 let show_loading = text.trim().is_empty();
-                inner.view(id!(loading_container)).set_visible(show_loading);
+                inner.view(id!(loading_container)).set_visible(cx, show_loading);
 
                 let mut loading_widget = inner.chat_line_loading(id!(loading_container.loading));
                 if show_loading {
@@ -465,7 +465,7 @@ impl ChatLineRef {
                     loading_widget.stop_animation();
                 }
 
-                inner.show_or_hide_message_label(true);
+                inner.show_or_hide_message_label(cx, true);
             }
             ChatLineState::OnEdit => {}
         }
@@ -478,7 +478,7 @@ impl ChatLineRef {
         inner.message_id = message_id;
     }
 
-    pub fn set_actions_enabled(&mut self, _cx: &mut Cx, enabled: bool) {
+    pub fn set_actions_enabled(&mut self, cx: &mut Cx, enabled: bool) {
         let Some(mut inner) = self.borrow_mut() else {
             return;
         };
@@ -489,14 +489,14 @@ impl ChatLineRef {
             }
         } else {
             inner.edition_state = ChatLineState::NotEditable;
-            inner.view(id!(actions_section.actions)).set_visible(false);
+            inner.view(id!(actions_section.actions)).set_visible(cx, false);
         }
     }
 
-    pub fn set_regenerate_button_visible(&mut self, visible: bool) {
+    pub fn set_regenerate_button_visible(&mut self, cx: &mut Cx, visible: bool) {
         let Some(inner) = self.borrow_mut() else {
             return;
         };
-        inner.button(id!(save_and_regenerate)).set_visible(visible);
+        inner.button(id!(save_and_regenerate)).set_visible(cx, visible);
     }
 }

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -424,7 +424,7 @@ impl Widget for ChatPanel {
         if self.focus_on_prompt_input_pending {
             self.focus_on_prompt_input_pending = false;
 
-            self.prompt_input(id!(main_prompt_input)).reset_text(true);
+            self.prompt_input(id!(main_prompt_input)).reset_text(cx,true);
         }
 
         let message_list_uid = self.portal_list(id!(chat)).widget_uid();
@@ -682,8 +682,8 @@ impl ChatPanel {
         match button {
             PromptInputButton::Send => {
                 // The send button is enabled or not based on the prompt input
-                send_button.set_visible(true);
-                send_button.set_enabled(enabled);
+                send_button.set_visible(cx, true);
+                send_button.set_enabled(cx, enabled);
                 send_button.apply_over(
                     cx,
                     live! {
@@ -692,11 +692,11 @@ impl ChatPanel {
                         }
                     },
                 );
-                stop_button.set_visible(false);
+                stop_button.set_visible(cx, false);
             }
             PromptInputButton::EnabledStop => {
-                stop_button.set_visible(true);
-                stop_button.set_enabled(true);
+                stop_button.set_visible(cx, true);
+                stop_button.set_enabled(cx, true);
                 stop_button.apply_over(
                     cx,
                     live! {
@@ -705,11 +705,11 @@ impl ChatPanel {
                         }
                     },
                 );
-                send_button.set_visible(false);
+                send_button.set_visible(cx, false);
             }
             PromptInputButton::DisabledStop => {
-                stop_button.set_visible(true);
-                stop_button.set_enabled(false);
+                stop_button.set_visible(cx, true);
+                stop_button.set_enabled(cx, false);
                 stop_button.apply_over(
                     cx,
                     live! {
@@ -718,7 +718,7 @@ impl ChatPanel {
                         }
                     },
                 );
-                send_button.set_visible(false);
+                send_button.set_visible(cx, false);
             }
         }
     }
@@ -807,7 +807,7 @@ impl ChatPanel {
             store.send_message_to_current_entity(prompt, regenerate_from);
         }
 
-        self.prompt_input(id!(main_prompt_input)).reset_text(false);
+        self.prompt_input(id!(main_prompt_input)).reset_text(cx,false);
 
         // Scroll to the bottom when the message is sent
         self.scroll_messages_to_bottom(cx);
@@ -815,7 +815,7 @@ impl ChatPanel {
     }
 
     fn update_view(&mut self, cx: &mut Cx2d, scope: &mut Scope) {
-        self.update_visibilities();
+        self.update_visibilities(cx);
         self.update_prompt_input(cx);
 
         match self.state {
@@ -828,7 +828,7 @@ impl ChatPanel {
                         let empty_view = self.view(id!(empty_conversation));
                         empty_view
                             .view(id!(avatar_section.model))
-                            .set_visible(false);
+                            .set_visible(cx, false);
                         empty_view
                             .chat_agent_avatar(id!(avatar_section.agent))
                             .set_visible(true);
@@ -840,14 +840,14 @@ impl ChatPanel {
                     }
                     _ => {
                         let empty_view = self.view(id!(empty_conversation));
-                        empty_view.view(id!(avatar_section.model)).set_visible(true);
+                        empty_view.view(id!(avatar_section.model)).set_visible(cx, true);
                         empty_view
                             .chat_agent_avatar(id!(avatar_section.agent))
                             .set_visible(false);
 
                         empty_view
                             .label(id!(avatar_label))
-                            .set_text(&get_model_initial_letter(store).unwrap_or('A').to_string());
+                            .set_text(cx,&get_model_initial_letter(store).unwrap_or('A').to_string());
                     }
                 }
             }
@@ -855,7 +855,7 @@ impl ChatPanel {
         }
     }
 
-    fn update_visibilities(&mut self) {
+    fn update_visibilities(&mut self, cx: &mut Cx) {
         let empty_conversation = self.view(id!(empty_conversation));
         let jump_to_bottom = self.button(id!(jump_to_bottom));
         let main = self.view(id!(main));
@@ -864,38 +864,38 @@ impl ChatPanel {
 
         match self.state {
             // State::NoModelsAvailable => {
-            //     empty_conversation.set_visible(false);
-            //     jump_to_bottom.set_visible(false);
-            //     main.set_visible(false);
-            //     no_model.set_visible(false);
+            //     empty_conversation.set_visible(cx, false);
+            //     jump_to_bottom.set_visible(cx, false);
+            //     main.set_visible(cx, false);
+            //     no_model.set_visible(cx, false);
 
-            //     no_downloaded_model.set_visible(true);
+            //     no_downloaded_model.set_visible(cx, true);
             // }
             State::NoModelsAvailable | State::NoModelSelected => {
-                empty_conversation.set_visible(false);
-                jump_to_bottom.set_visible(false);
-                main.set_visible(false);
-                no_downloaded_model.set_visible(false);
+                empty_conversation.set_visible(cx, false);
+                jump_to_bottom.set_visible(cx, false);
+                main.set_visible(cx, false);
+                no_downloaded_model.set_visible(cx, false);
 
-                no_model.set_visible(true);
+                no_model.set_visible(cx, true);
             }
             State::ModelSelectedWithEmptyChat { .. } => {
-                jump_to_bottom.set_visible(false);
-                no_downloaded_model.set_visible(false);
-                no_model.set_visible(false);
+                jump_to_bottom.set_visible(cx, false);
+                no_downloaded_model.set_visible(cx, false);
+                no_model.set_visible(cx, false);
 
-                empty_conversation.set_visible(true);
-                main.set_visible(true);
+                empty_conversation.set_visible(cx, true);
+                main.set_visible(cx, true);
             }
             State::ModelSelectedWithChat {
                 sticked_to_bottom, ..
             } => {
-                empty_conversation.set_visible(false);
-                no_downloaded_model.set_visible(false);
-                no_model.set_visible(false);
+                empty_conversation.set_visible(cx, false);
+                no_downloaded_model.set_visible(cx, false);
+                no_model.set_visible(cx, false);
 
-                main.set_visible(true);
-                jump_to_bottom.set_visible(!sticked_to_bottom);
+                main.set_visible(cx, true);
+                jump_to_bottom.set_visible(cx, !sticked_to_bottom);
             }
             _ => {}
         }
@@ -919,16 +919,17 @@ impl ChatPanel {
                     chat_line_item = item.as_chat_line();
 
                     let username = chat_line_data.username.as_ref().map_or("", String::as_str);
-                    chat_line_item.set_sender_name(&username);
-                    chat_line_item.set_regenerate_button_visible(false);
+                    chat_line_item.set_sender_name(cx, &username);
+                    chat_line_item.set_regenerate_button_visible(cx,false);
 
                     match &chat_line_data.entity {
                         Some(ChatEntityId::Agent(agent_id)) => {
                             let agent = store.chats.get_agent_or_placeholder(&agent_id);
-                            chat_line_item.set_model_avatar(agent);
+                            chat_line_item.set_model_avatar(cx, agent);
                         }
                         Some(ChatEntityId::ModelFile(_)) => {
                             chat_line_item.set_model_avatar_text(
+                                cx,
                                 &get_model_initial_letter(store).unwrap().to_string(),
                             );
                         }
@@ -937,7 +938,7 @@ impl ChatPanel {
                 } else {
                     item = list.item(cx, item_id, live_id!(UserChatLine));
                     chat_line_item = item.as_chat_line();
-                    chat_line_item.set_regenerate_button_visible(true);
+                    chat_line_item.set_regenerate_button_visible(cx, true);
                 };
 
                 chat_line_item.set_message_id(chat_line_data.id);

--- a/src/chat/chat_params.rs
+++ b/src/chat/chat_params.rs
@@ -270,15 +270,15 @@ impl Widget for ChatParams {
 
             let system_prompt = self.text_input(id!(system_prompt));
 
-            temperature.set_value(ip.temperature.into());
-            top_p.set_value(ip.top_p.into());
-            max_tokens.set_value(ip.max_tokens.into());
-            frequency_penalty.set_value(ip.frequency_penalty.into());
-            presence_penalty.set_value(ip.presence_penalty.into());
-            stop.set_text(&ip.stop);
+            temperature.set_value(cx, ip.temperature as f64);
+            top_p.set_value(cx, ip.top_p as f64);
+            max_tokens.set_value(cx, ip.max_tokens as f64);
+            frequency_penalty.set_value(cx, ip.frequency_penalty as f64);
+            presence_penalty.set_value(cx, ip.presence_penalty as f64);
+            stop.set_text(cx,&ip.stop);
 
             let system_prompt_value = chat.system_prompt.clone().unwrap_or_default();
-            system_prompt.set_text(&system_prompt_value);
+            system_prompt.set_text(cx,&system_prompt_value);
 
             // Currently, `selected` and `set_selected` interact with the animator of
             // the widget to do what they do. To avoid some visual issues, we should not

--- a/src/chat/delete_chat_modal.rs
+++ b/src/chat/delete_chat_modal.rs
@@ -172,7 +172,7 @@ impl Widget for DeleteChatModal {
             chat_title
         );
         self.label(id!(wrapper.body.delete_prompt))
-            .set_text(&prompt_text);
+            .set_text(cx,&prompt_text);
 
         self.view
             .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))

--- a/src/chat/entity_button.rs
+++ b/src/chat/entity_button.rs
@@ -139,7 +139,7 @@ impl Widget for EntityButton {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         if self.server_url_visible {
-            self.view(id!(server_url)).set_visible(true);
+            self.view(id!(server_url)).set_visible(cx, true);
         }
 
         self.view.draw_walk(cx, scope, walk)
@@ -161,11 +161,11 @@ impl EntityButton {
         self.entity.as_ref()
     }
 
-    pub fn set_agent(&mut self, agent: &MofaAgent) {
-        self.set_entity(ChatEntityRef::Agent(agent));
+    pub fn set_agent(&mut self, cx: &mut Cx, agent: &MofaAgent) {
+        self.set_entity(cx, ChatEntityRef::Agent(agent));
     }
 
-    pub fn set_entity(&mut self, entity: ChatEntityRef) {
+    pub fn set_entity(&mut self, cx: &mut Cx, entity: ChatEntityRef) {
         self.visible = true;
 
         let name_label = self.label(id!(caption));
@@ -173,47 +173,47 @@ impl EntityButton {
         let mut avatar = self.chat_agent_avatar(id!(agent_avatar));
         let server_url = self.label(id!(server_url.label));
 
-        name_label.set_text(&entity.name());
+        name_label.set_text(cx,&entity.name());
 
         if let ChatEntityRef::Agent(agent) = entity {
             avatar.set_visible(true);
             avatar.set_agent(agent);
-            description_label.set_text(&agent.description);
+            description_label.set_text(cx,&agent.description);
             
             let formatted_server_url = agent.server_id.0
                 .strip_prefix("https://")
                 .or_else(|| agent.server_id.0.strip_prefix("http://"))
                 .unwrap_or(&agent.server_id.0);
-            server_url.set_text(formatted_server_url);
+            server_url.set_text(cx,formatted_server_url);
         } else {
             avatar.set_visible(false);
-            description_label.set_text("");
+            description_label.set_text(cx,"");
         }
 
         self.entity = Some(entity.id());
     }
 
-    pub fn set_description_visible(&mut self, visible: bool) {
-        self.view(id!(description)).set_visible(visible);
+    pub fn set_description_visible(&mut self, cx: &mut Cx, visible: bool) {
+        self.view(id!(description)).set_visible(cx, visible);
     }
 }
 
 impl EntityButtonRef {
-    pub fn set_description_visible(&mut self, visible: bool) {
+    pub fn set_description_visible(&mut self, cx: &mut Cx, visible: bool) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.set_description_visible(visible);
+            inner.set_description_visible(cx, visible);
         }
     }
 
-    pub fn set_agent(&mut self, agent: &MofaAgent) {
+    pub fn set_agent(&mut self, cx: &mut Cx, agent: &MofaAgent) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.set_agent(agent);
+            inner.set_agent(cx, agent);
         }
     }
 
-    pub fn set_entity(&mut self, entity: ChatEntityRef) {
+    pub fn set_entity(&mut self, cx: &mut Cx, entity: ChatEntityRef) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.set_entity(entity);
+            inner.set_entity(cx, entity);
         }
     }
 

--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -278,10 +278,10 @@ impl Widget for ModelSelector {
         self.update_loading_model_state(cx, store);
 
         if no_active_model(store) {
-            self.view(id!(choose)).set_visible(true);
-            self.view(id!(selected_agent)).set_visible(false);
-            self.view(id!(selected_model)).set_visible(false);
-            choose_label.set_text("Choose a Model or Agent");
+            self.view(id!(choose)).set_visible(cx, true);
+            self.view(id!(selected_agent)).set_visible(cx, false);
+            self.view(id!(selected_model)).set_visible(cx, false);
+            choose_label.set_text(cx,"Choose a Model or Agent");
             let color = vec3(0.0, 0.0, 0.0);
             choose_label.apply_over(
                 cx,
@@ -382,7 +382,7 @@ impl ModelSelector {
     }
 
     fn update_selected_model_info(&mut self, cx: &mut Cx, store: &Store) {
-        self.view(id!(choose)).set_visible(false);
+        self.view(id!(choose)).set_visible(cx, false);
 
         let is_loading = store.chats.model_loader.is_loading();
         let loaded_file = store.chats.loaded_model.as_ref();
@@ -393,9 +393,9 @@ impl ModelSelector {
             .and_then(|c| c.borrow().associated_entity.clone());
 
         if let Some(ChatEntityId::Agent(agent)) = chat_entity {
-            self.view(id!(selected_model)).set_visible(false);
+            self.view(id!(selected_model)).set_visible(cx, false);
             let selected_view = self.view(id!(selected_agent));
-            selected_view.set_visible(true);
+            selected_view.set_visible(cx, true);
 
             let agent = store.chats.get_agent_or_placeholder(&agent);
             selected_view.apply_over(
@@ -420,9 +420,9 @@ impl ModelSelector {
             store.chats.model_loader.file_id().as_ref() == file.as_ref().map(|f| &f.id);
 
         if let Some(file) = file {
-            self.view(id!(selected_agent)).set_visible(false);
+            self.view(id!(selected_agent)).set_visible(cx, false);
             let selected_view = self.view(id!(selected_model));
-            selected_view.set_visible(true);
+            selected_view.set_visible(cx, true);
 
             let text_color = if Some(&file.id) == loaded_file.map(|f| &f.id) {
                 hex_rgb_color(0x000000)

--- a/src/chat/prompt_input.rs
+++ b/src/chat/prompt_input.rs
@@ -228,7 +228,7 @@ impl WidgetMatchEvent for PromptInput {
         if let Some(item) = prompt.item_selected(actions) {
             let entity_button = item.entity_button(id!(button));
             let entity = entity_button.get_entity_id().unwrap();
-            self.on_entity_selected(scope, &*entity);
+            self.on_entity_selected(cx, scope, &*entity);
         }
 
         if prompt.should_build_items(actions) {
@@ -250,14 +250,14 @@ impl WidgetMatchEvent for PromptInput {
             {
                 if idx == 0 {
                     let label = WidgetRef::new_from_ptr(cx, self.section_label_template);
-                    label.set_text("Agents");
+                    label.set_text(cx,"Agents");
                     prompt.add_unselectable_item(label);
                 }
 
                 let option = WidgetRef::new_from_ptr(cx, self.entity_template);
                 let mut entity_button = option.entity_button(id!(button));
-                entity_button.set_entity(agent.into());
-                entity_button.set_description_visible(true);
+                entity_button.set_entity(cx, agent.into());
+                entity_button.set_description_visible(cx, true);
                 prompt.add_item(option);
             }
 
@@ -271,30 +271,30 @@ impl WidgetMatchEvent for PromptInput {
             {
                 if idx == 0 {
                     let label = WidgetRef::new_from_ptr(cx, self.section_label_template);
-                    label.set_text("Models");
+                    label.set_text(cx,"Models");
                     prompt.add_unselectable_item(label);
                 }
 
                 let option = WidgetRef::new_from_ptr(cx, self.entity_template);
                 let mut entity_button = option.entity_button(id!(button));
-                entity_button.set_entity(file.into());
-                entity_button.set_description_visible(true);
+                entity_button.set_entity(cx, file.into());
+                entity_button.set_description_visible(cx, true);
                 prompt.add_item(option);
             }
         }
 
         if prompt.text_input_ref().escape(actions) {
-            self.on_deselected();
+            self.on_deselected(cx);
         }
 
         if self.button(id!(deselect_button)).clicked(actions) {
-            self.on_deselected();
+            self.on_deselected(cx);
         }
 
         for action in actions {
             match action.cast() {
                 ModelSelectorAction::ModelSelected(_) | ModelSelectorAction::AgentSelected(_) => {
-                    self.on_deselected()
+                    self.on_deselected(cx);
                 }
                 _ => (),
             }
@@ -302,14 +302,14 @@ impl WidgetMatchEvent for PromptInput {
 
         for action in actions.iter().filter_map(|a| a.as_widget_action()) {
             if let ChatAction::Start(_) = action.cast() {
-                self.on_deselected();
+                self.on_deselected(cx);
             }
         }
     }
 }
 
 impl PromptInput {
-    fn on_entity_selected(&mut self, scope: &mut Scope, entity: &ChatEntityId) {
+    fn on_entity_selected(&mut self, cx: &mut Cx, scope: &mut Scope, entity: &ChatEntityId) {
         let store = scope.data.get::<Store>().unwrap();
 
         let mut agent_avatar = self.chat_agent_avatar(id!(agent_avatar));
@@ -318,7 +318,7 @@ impl PromptInput {
         match entity {
             ChatEntityId::Agent(agent_id) => {
                 let agent = store.chats.get_agent_or_placeholder(agent_id);
-                label.set_text(&agent.name);
+                label.set_text(cx,&agent.name);
                 agent_avatar.set_agent(agent);
             }
             ChatEntityId::ModelFile(file_id) => {
@@ -327,18 +327,18 @@ impl PromptInput {
                     .downloads
                     .get_file(file_id)
                     .expect("selected file not found");
-                label.set_text(&file.name);
+                label.set_text(cx,&file.name);
                 agent_avatar.set_visible(false);
             }
         }
 
         self.entity_selected = Some(entity.clone());
-        self.view(id!(selected_bubble)).set_visible(true);
+        self.view(id!(selected_bubble)).set_visible(cx, true);
     }
 
-    fn on_deselected(&mut self) {
+    fn on_deselected(&mut self, cx: &mut Cx) {
         self.entity_selected = None;
-        self.view(id!(selected_bubble)).set_visible(false);
+        self.view(id!(selected_bubble)).set_visible(cx, false);
     }
 }
 
@@ -358,13 +358,13 @@ impl LiveHook for PromptInput {
 }
 
 impl PromptInputRef {
-    pub fn reset_text(&mut self, set_key_focus: bool) {
+    pub fn reset_text(&mut self, cx: &mut Cx, set_key_focus: bool) {
         let mut prompt = self.command_text_input(id!(prompt));
 
         if set_key_focus {
             prompt.request_text_input_focus();
         }
 
-        prompt.reset();
+        prompt.reset(cx);
     }
 }

--- a/src/landing/download_item.rs
+++ b/src/landing/download_item.rs
@@ -227,13 +227,13 @@ impl Widget for DownloadItem {
         self.file_id = Some(download.file.id.clone());
 
         self.label(id!(filename))
-            .set_text(download.file.name.as_str());
+            .set_text(cx,download.file.name.as_str());
 
         self.label(id!(architecture_tag.caption))
-            .set_text(download.model.architecture.as_str());
+            .set_text(cx,download.model.architecture.as_str());
 
         self.label(id!(params_size_tag.caption))
-            .set_text(&&download.model.requires.as_str());
+            .set_text(cx,&&download.model.requires.as_str());
 
         let progress_bar_width = download.progress * 6.0; // 6.0 = 600px / 100%
         let label = self.label(id!(progress));
@@ -241,7 +241,7 @@ impl Widget for DownloadItem {
             PendingDownloadsStatus::Initializing => {
                 let downloading_color = vec3(0.035, 0.572, 0.314); //#099250
 
-                label.set_text(&format!("Downloading {:.1}%", download.progress));
+                label.set_text(cx,&format!("Downloading {:.1}%", download.progress));
                 label.apply_over(
                     cx,
                     live! { draw_text: { color: (downloading_color) }
@@ -256,15 +256,15 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(false);
-                self.button(id!(play_button)).set_visible(false);
-                self.button(id!(retry_button)).set_visible(false);
-                self.button(id!(cancel_button)).set_visible(false);
+                self.button(id!(pause_button)).set_visible(cx, false);
+                self.button(id!(play_button)).set_visible(cx, false);
+                self.button(id!(retry_button)).set_visible(cx, false);
+                self.button(id!(cancel_button)).set_visible(cx, false);
             }
             PendingDownloadsStatus::Downloading => {
                 let downloading_color = vec3(0.035, 0.572, 0.314); //#099250
 
-                label.set_text(&format!("Downloading {:.1}%", download.progress));
+                label.set_text(cx,&format!("Downloading {:.1}%", download.progress));
                 label.apply_over(
                     cx,
                     live! { draw_text: { color: (downloading_color) }
@@ -279,15 +279,15 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(true);
-                self.button(id!(play_button)).set_visible(false);
-                self.button(id!(retry_button)).set_visible(false);
-                self.button(id!(cancel_button)).set_visible(true);
+                self.button(id!(pause_button)).set_visible(cx, true);
+                self.button(id!(play_button)).set_visible(cx, false);
+                self.button(id!(retry_button)).set_visible(cx, false);
+                self.button(id!(cancel_button)).set_visible(cx, true);
             }
             PendingDownloadsStatus::Paused => {
                 let paused_color = vec3(0.4, 0.44, 0.52); //#667085
 
-                label.set_text(&format!("Paused {:.1}%", download.progress));
+                label.set_text(cx,&format!("Paused {:.1}%", download.progress));
                 label.apply_over(
                     cx,
                     live! { draw_text: { color: (paused_color) }
@@ -302,15 +302,15 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(false);
-                self.button(id!(play_button)).set_visible(true);
-                self.button(id!(retry_button)).set_visible(false);
-                self.button(id!(cancel_button)).set_visible(true);
+                self.button(id!(pause_button)).set_visible(cx, false);
+                self.button(id!(play_button)).set_visible(cx, true);
+                self.button(id!(retry_button)).set_visible(cx, false);
+                self.button(id!(cancel_button)).set_visible(cx, true);
             }
             PendingDownloadsStatus::Error => {
                 let failed_color = vec3(0.7, 0.11, 0.09); // #B42318
 
-                label.set_text(&format!("Error {:.1}%", download.progress));
+                label.set_text(cx,&format!("Error {:.1}%", download.progress));
                 label.apply_over(
                     cx,
                     live! { draw_text: { color: (failed_color) }
@@ -325,10 +325,10 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(false);
-                self.button(id!(play_button)).set_visible(false);
-                self.button(id!(retry_button)).set_visible(true);
-                self.button(id!(cancel_button)).set_visible(true);
+                self.button(id!(pause_button)).set_visible(cx, false);
+                self.button(id!(play_button)).set_visible(cx, false);
+                self.button(id!(retry_button)).set_visible(cx, true);
+                self.button(id!(cancel_button)).set_visible(cx, true);
             }
         }
 
@@ -337,7 +337,7 @@ impl Widget for DownloadItem {
             .unwrap_or("-".to_string());
 
         self.label(id!(downloaded_size))
-            .set_text(&format!("{} / {}", downloaded_size, total_size));
+            .set_text(cx,&format!("{} / {}", downloaded_size, total_size));
 
         self.view.draw_walk(cx, scope, walk)
     }

--- a/src/landing/downloads.rs
+++ b/src/landing/downloads.rs
@@ -166,14 +166,14 @@ impl Widget for Downloads {
             })
             .count();
         self.label(id!(downloading_count))
-            .set_text(&format!("{} downloading", download_count));
+            .set_text(cx,&format!("{} downloading", download_count));
 
         let paused_count = pending_downloads
             .iter()
             .filter(|d| matches!(d.status, PendingDownloadsStatus::Paused))
             .count();
         self.label(id!(paused_count))
-            .set_text(&format!("{} paused", paused_count));
+            .set_text(cx,&format!("{} paused", paused_count));
 
         let failed_count = pending_downloads
             .iter()
@@ -182,9 +182,9 @@ impl Widget for Downloads {
 
         if failed_count > 0 {
             self.label(id!(failed_count))
-                .set_text(&format!("{} failed", failed_count));
+                .set_text(cx,&format!("{} failed", failed_count));
         } else {
-            self.label(id!(failed_count)).set_text("");
+            self.label(id!(failed_count)).set_text(cx,"");
         }
 
         while let Some(view_item) = self.view.draw_walk(cx, &mut Scope::empty(), walk).step() {

--- a/src/landing/landing_screen.rs
+++ b/src/landing/landing_screen.rs
@@ -84,18 +84,18 @@ impl Widget for LandingScreen {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let search = &scope.data.get::<Store>().unwrap().search;
         if search.is_pending() || search.was_error() {
-            self.view(id!(heading_with_filters)).set_visible(false);
+            self.view(id!(heading_with_filters)).set_visible(cx, false);
         } else if let Some(keyword) = search.keyword.clone() {
-            self.view(id!(heading_with_filters)).set_visible(true);
+            self.view(id!(heading_with_filters)).set_visible(cx, true);
 
             let models = &search.models;
             let models_count = models.len();
             self.label(id!(heading_with_filters.results))
-                .set_text(&format!("{} Results", models_count));
+                .set_text(cx,&format!("{} Results", models_count));
             self.label(id!(heading_with_filters.keyword))
-                .set_text(&format!(" for \"{}\"", keyword));
+                .set_text(cx,&format!(" for \"{}\"", keyword));
         } else {
-            self.view(id!(heading_with_filters)).set_visible(false);
+            self.view(id!(heading_with_filters)).set_visible(cx, false);
         }
 
         self.view.draw_walk(cx, scope, walk)

--- a/src/landing/model_card.rs
+++ b/src/landing/model_card.rs
@@ -348,26 +348,26 @@ impl Widget for ModelCard {
         self.model_id = model.model_id.clone();
 
         let name = &model.name;
-        self.label(id!(model_name)).set_text(name);
+        self.label(id!(model_name)).set_text(cx,name);
 
         let download_count = &model.download_count;
         self.label(id!(model_download_count.attr_value))
-            .set_text(&format!("{}", download_count));
+            .set_text(cx,&format!("{}", download_count));
 
         let like_count = &model.like_count;
         self.label(id!(model_like_count.attr_value))
-            .set_text(&format!("{}", like_count));
+            .set_text(cx,&format!("{}", like_count));
 
         let size = &model.size;
-        self.label(id!(model_size_tag.attr_value)).set_text(size);
+        self.label(id!(model_size_tag.attr_value)).set_text(cx,size);
 
         let requires = &model.requires;
         self.label(id!(model_requires_tag.attr_value))
-            .set_text(requires);
+            .set_text(cx,requires);
 
         let architecture = &model.architecture;
         self.label(id!(model_architecture_tag.attr_value))
-            .set_text(architecture);
+            .set_text(cx,architecture);
 
         let summary = &model.summary;
         const MAX_SUMMARY_LENGTH: usize = 500;
@@ -380,14 +380,14 @@ impl Widget for ModelCard {
         } else {
             summary.to_string()
         };
-        self.label(id!(model_summary)).set_text(&trimmed_summary);
+        self.label(id!(model_summary)).set_text(cx,&trimmed_summary);
 
         let author_name = &model.author.name;
         let author_url = &model.author.url;
         let mut author_external_link = self.external_link(id!(author_link));
         author_external_link
             .link_label(id!(link))
-            .set_text(author_name);
+            .set_text(cx,author_name);
         author_external_link.set_url(author_url);
 
         let model_hugging_face_url = hugging_face_model_url(&model.model_id);
@@ -396,11 +396,11 @@ impl Widget for ModelCard {
 
         let author_description = &model.author.description;
         self.label(id!(author_description))
-            .set_text(author_description);
+            .set_text(cx,author_description);
 
         let released_at_str = formatted_model_release_date(&model);
         self.label(id!(model_released_at_tag.attr_value))
-            .set_text(&released_at_str);
+            .set_text(cx,&released_at_str);
 
         self.view.draw_walk(cx, scope, walk)
     }
@@ -444,10 +444,10 @@ impl Widget for ModelCardViewAllModal {
         let model = &scope.data.get::<ModelWithDownloadInfo>().unwrap();
 
         let name = &model.name;
-        self.label(id!(view_all_model_name)).set_text(name);
+        self.label(id!(view_all_model_name)).set_text(cx,name);
 
         let summary = &model.summary;
-        self.label(id!(view_all_model_summary)).set_text(summary);
+        self.label(id!(view_all_model_summary)).set_text(cx,summary);
 
         self.view
             .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))

--- a/src/landing/model_files.rs
+++ b/src/landing/model_files.rs
@@ -208,10 +208,10 @@ impl Widget for ModelFiles {
         let featured_count = model.files.iter().filter(|f| f.file.featured).count();
 
         let show_all_button = self.radio_button(id!(tab_buttons.show_all_button));
-        show_all_button.set_text(&format!("All Files ({})", files_count));
+        show_all_button.set_text(cx,&format!("All Files ({})", files_count));
 
         let show_all_button = self.radio_button(id!(tab_buttons.only_recommended_button));
-        show_all_button.set_text(&format!("Only Recommended Files ({})", featured_count));
+        show_all_button.set_text(cx,&format!("Only Recommended Files ({})", featured_count));
 
         let _ = self.view.draw_walk(cx, scope, walk);
 

--- a/src/landing/model_list.rs
+++ b/src/landing/model_list.rs
@@ -211,7 +211,7 @@ impl Widget for ModelList {
                         match items[item_id] {
                             Item::Header(text) => {
                                 let item = list.item(cx, item_id, live_id!(Header));
-                                item.set_text(text);
+                                item.set_text(cx,text);
                                 item.draw_all(cx, &mut Scope::empty());
                             }
                             Item::AgentRow {
@@ -240,8 +240,8 @@ impl Widget for ModelList {
                                                 },
                                             );
                                             let mut button = cell.entity_button(id!(button));
-                                            button.set_agent(agent);
-                                            button.set_description_visible(true);
+                                            button.set_agent(cx, agent);
+                                            button.set_description_visible(cx, true);
                                         }
                                     });
 
@@ -249,7 +249,7 @@ impl Widget for ModelList {
                             }
                             Item::NoAgentsWarning(text) => {
                                 let item = list.item(cx, item_id, live_id!(NoAgentsWarning));
-                                item.set_text(text);
+                                item.set_text(cx,text);
                                 item.draw_all(cx, &mut Scope::empty());
                             }
                             Item::Model(model) => {
@@ -302,8 +302,8 @@ impl WidgetMatchEvent for ModelList {
 
             match action.cast() {
                 StoreAction::Search(_) | StoreAction::ResetSearch => {
-                    self.view(id!(search_error)).set_visible(false);
-                    self.view(id!(loading)).set_visible(true);
+                    self.view(id!(search_error)).set_visible(cx, false);
+                    self.view(id!(loading)).set_visible(cx, true);
                     self.search_loading(id!(search_loading)).animate(cx);
                     portal_list.set_first_id_and_scroll(0, 0.0);
 
@@ -329,7 +329,7 @@ impl ModelList {
     fn update_loading_and_error_message(&mut self, cx: &mut Cx, scope: &mut Scope) {
         let store = scope.data.get::<Store>().unwrap();
         let is_loading = store.search.is_pending();
-        self.view(id!(loading)).set_visible(is_loading);
+        self.view(id!(loading)).set_visible(cx, is_loading);
         if is_loading {
             self.search_loading(id!(search_loading)).animate(cx);
         } else {
@@ -337,6 +337,6 @@ impl ModelList {
         }
 
         let is_errored = store.search.was_error();
-        self.view(id!(search_error)).set_visible(is_errored);
+        self.view(id!(search_error)).set_visible(cx, is_errored);
     }
 }

--- a/src/landing/search_bar.rs
+++ b/src/landing/search_bar.rs
@@ -195,14 +195,14 @@ impl WidgetMatchEvent for SearchBar {
         }
 
         if let Some(text) = input.changed(actions) {
-            clear_text_button.set_visible(!text.is_empty());
+            clear_text_button.set_visible(cx, !text.is_empty());
             cx.stop_timer(self.search_timer);
             self.search_timer = cx.start_timeout(self.search_debounce_time);
         }
 
         if self.button(id!(clear_text_button)).clicked(actions) {
-            input.set_text_and_redraw(cx, "");
-            clear_text_button.set_visible(false);
+            input.set_text(cx, "");
+            clear_text_button.set_visible(cx, false);
             input.set_key_focus(cx);
 
             cx.action(StoreAction::ResetSearch);
@@ -235,7 +235,7 @@ impl SearchBarRef {
 
         inner
             .sorting(id!(search_sorting))
-            .set_selected_item(selected_sort);
+            .set_selected_item(cx, selected_sort);
         inner.animator_play(cx, id!(search_bar.collapsed));
     }
 

--- a/src/landing/sorting.rs
+++ b/src/landing/sorting.rs
@@ -194,7 +194,7 @@ impl SortingRef {
         );
     }
 
-    pub fn set_selected_item(&self, criteria: SortCriteria) {
+    pub fn set_selected_item(&self, cx: &mut Cx, criteria: SortCriteria) {
         let Some(inner) = self.borrow_mut() else {
             return;
         };
@@ -204,6 +204,6 @@ impl SortingRef {
             SortCriteria::MostLikes => 2,
             SortCriteria::LeastLikes => 3,
         };
-        inner.drop_down(id!(options)).set_selected_item(criteria_id);
+        inner.drop_down(id!(options)).set_selected_item(cx, criteria_id);
     }
 }

--- a/src/my_models/delete_model_modal.rs
+++ b/src/my_models/delete_model_modal.rs
@@ -165,7 +165,7 @@ impl Widget for DeleteModelModal {
             downloaded_file.file.name
         );
         self.label(id!(wrapper.body.delete_prompt))
-            .set_text(&prompt_text);
+            .set_text(cx,&prompt_text);
 
         self.view
             .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))

--- a/src/my_models/downloaded_files_row.rs
+++ b/src/my_models/downloaded_files_row.rs
@@ -209,7 +209,7 @@ impl Widget for DownloadedFilesRow {
         // Name tag
         let name = human_readable_name(&downloaded_file.file.name);
         self.label(id!(h_wrapper.model_file.h_wrapper.name_tag.name))
-            .set_text(&name);
+            .set_text(cx,&name);
 
         // Base model tag
         let base_model = dash_if_empty(&downloaded_file.model.architecture);
@@ -218,7 +218,7 @@ impl Widget for DownloadedFilesRow {
             .base_model_tag
             .base_model
             .attr_name))
-            .set_text(&base_model);
+            .set_text(cx,&base_model);
 
         // Parameters tag
         let parameters = dash_if_empty(&downloaded_file.model.size);
@@ -227,7 +227,7 @@ impl Widget for DownloadedFilesRow {
             .parameters_tag
             .parameters
             .attr_name))
-            .set_text(&parameters);
+            .set_text(cx,&parameters);
 
         // Version tag
         let filename = format!(
@@ -235,17 +235,17 @@ impl Widget for DownloadedFilesRow {
             downloaded_file.model.name, downloaded_file.file.name
         );
         self.label(id!(h_wrapper.model_file.model_version_tag.version))
-            .set_text(&filename);
+            .set_text(cx,&filename);
 
         // File size tag
         let file_size = format_model_size(&downloaded_file.file.size).unwrap_or("-".to_string());
         self.label(id!(h_wrapper.file_size_tag.label))
-            .set_text(&file_size);
+            .set_text(cx,&file_size);
 
         // Added date tag
         let formatted_date = downloaded_file.downloaded_at.format("%d/%m/%Y").to_string();
         self.label(id!(h_wrapper.date_added_tag.label))
-            .set_text(&formatted_date);
+            .set_text(cx,&formatted_date);
 
         self.view.draw_walk(cx, scope, walk)
     }

--- a/src/my_models/model_info_modal.rs
+++ b/src/my_models/model_info_modal.rs
@@ -191,14 +191,14 @@ impl Widget for ModelInfoModal {
 
         // filename
         self.label(id!(title.filename))
-            .set_text(&downloaded_file.file.name);
+            .set_text(cx,&downloaded_file.file.name);
 
         // file path
         if let Some(path) = &downloaded_file.file.downloaded_path {
             self.html(id!(file_dir.path))
-                .set_text(&format!("<pre>{}</pre>", path));
+                .set_text(cx,&format!("<pre>{}</pre>", path));
         } else {
-            self.view(id!(file_dir)).set_visible(false);
+            self.view(id!(file_dir)).set_visible(cx, false);
         }
 
         // metadata
@@ -206,7 +206,7 @@ impl Widget for ModelInfoModal {
             .expect("Could not serialize model data into json");
         let metadata = format!("<pre>{}</pre>", self.stringified_model_data);
 
-        self.html(id!(wrapper.body.metadata)).set_text(&metadata);
+        self.html(id!(wrapper.body.metadata)).set_text(cx,&metadata);
 
         self.view
             .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))

--- a/src/my_models/my_models_screen.rs
+++ b/src/my_models/my_models_screen.rs
@@ -195,11 +195,11 @@ impl Widget for MyModelsScreen {
 
         let summary = generate_models_summary(&downloaded_files);
         let models_summary_label = self.view.label(id!(header.models_summary));
-        models_summary_label.set_text(&summary);
+        models_summary_label.set_text(cx,&summary);
 
         self.view
             .button(id!(show_in_files))
-            .set_text(&file_manager_label());
+            .set_text(cx,&file_manager_label());
 
         self.view.draw_walk(cx, scope, walk)
     }

--- a/src/settings/delete_server_modal.rs
+++ b/src/settings/delete_server_modal.rs
@@ -165,7 +165,7 @@ impl Widget for DeleteServerModal {
             self.server_address
         );
 
-        self.label(id!(delete_prompt)).set_text(&prompt_text);
+        self.label(id!(delete_prompt)).set_text(cx,&prompt_text);
 
         self.view
             .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))

--- a/src/settings/mofa_settings.rs
+++ b/src/settings/mofa_settings.rs
@@ -281,7 +281,7 @@ impl Widget for MofaServers {
 
                         // hide the separator for the first item
                         if item_id == 0 {
-                            item.view(id!(separator)).set_visible(false);
+                            item.view(id!(separator)).set_visible(cx, false);
                         }
 
                         let server = &servers[item_id].clone();
@@ -302,7 +302,7 @@ impl WidgetMatchEvent for MofaServers {
         let add_server_input = self.view.text_input(id!(add_server_input));
         if let Some(address) = add_server_input.returned(actions) {
             store.chats.register_mofa_server(address);
-            add_server_input.set_text("");
+            add_server_input.set_text(cx,"");
 
             self.redraw(cx);
         }
@@ -328,17 +328,17 @@ impl Widget for MofaServerItem {
         let server = scope.props.get::<MofaServer>().unwrap();
         self.server_address = server.client.address.clone();
 
-        self.update_connection_status(&server.connection_status);
+        self.update_connection_status(cx, &server.connection_status);
 
         self.label(id!(address_editable.mofa_address_label))
-            .set_text(&server.client.address);
+            .set_text(cx,&server.client.address);
 
         if server.is_local() {
-            self.view.view(id!(icon_local)).set_visible(true);
-            self.view.view(id!(icon_remote)).set_visible(false);
+            self.view.view(id!(icon_local)).set_visible(cx, true);
+            self.view.view(id!(icon_remote)).set_visible(cx, false);
         } else {
-            self.view.view(id!(icon_local)).set_visible(false);
-            self.view.view(id!(icon_remote)).set_visible(true);
+            self.view.view(id!(icon_local)).set_visible(cx, false);
+            self.view.view(id!(icon_remote)).set_visible(cx, true);
         };
 
         self.view.draw_walk(cx, scope, walk)
@@ -358,7 +358,7 @@ impl WidgetMatchEvent for MofaServerItem {
             .finger_down(actions)
         {
             store.chats.test_mofa_server_and_fetch_agents(&self.server_address);
-            self.update_connection_status(&MofaServerConnectionStatus::Connecting);
+            self.update_connection_status(cx, &MofaServerConnectionStatus::Connecting);
             self.redraw(cx);
         }
 
@@ -372,12 +372,12 @@ impl WidgetMatchEvent for MofaServerItem {
 
 impl MofaServerItem {
     /// Toggles the visibility of the connection status icons based on the connection status
-    fn update_connection_status(&mut self, connection_status: &MofaServerConnectionStatus) {
+    fn update_connection_status(&mut self, cx: &mut Cx, connection_status: &MofaServerConnectionStatus) {
         self.view(id!(connection_status_success))
-            .set_visible(*connection_status == MofaServerConnectionStatus::Connected);
+            .set_visible(cx, *connection_status == MofaServerConnectionStatus::Connected);
         self.view(id!(connection_status_failure))
-            .set_visible(*connection_status == MofaServerConnectionStatus::Disconnected);
+            .set_visible(cx, *connection_status == MofaServerConnectionStatus::Disconnected);
         self.view(id!(connection_status_loading))
-            .set_visible(*connection_status == MofaServerConnectionStatus::Connecting);
+            .set_visible(cx, *connection_status == MofaServerConnectionStatus::Connecting);
     }
 }

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -223,12 +223,12 @@ impl Widget for SettingsScreen {
 
         match self.server_port_state {
             ServerPortState::OnEdit => {
-                self.view.view(id!(port_editable)).set_visible(false);
-                self.view.view(id!(port_on_edit)).set_visible(true);
+                self.view.view(id!(port_editable)).set_visible(cx, false);
+                self.view.view(id!(port_on_edit)).set_visible(cx, true);
             }
             ServerPortState::Editable => {
-                self.view.view(id!(port_editable)).set_visible(true);
-                self.view.view(id!(port_on_edit)).set_visible(false);
+                self.view.view(id!(port_editable)).set_visible(cx, true);
+                self.view.view(id!(port_on_edit)).set_visible(cx, false);
             }
         }
 
@@ -243,16 +243,16 @@ impl Widget for SettingsScreen {
         if let Some(port) = port {
             self.view
                 .view(id!(local_server_options.no_model))
-                .set_visible(false);
+                .set_visible(cx, false);
             self.view
                 .view(id!(local_server_options.main))
-                .set_visible(true);
+                .set_visible(cx, true);
 
             self.view
                 .label(id!(port_number_label))
-                .set_text(&format!("{}", port));
+                .set_text(cx,&format!("{}", port));
 
-            self.view.code_view(id!(code_snippet)).set_text(&format!(
+            self.view.code_view(id!(code_snippet)).set_text(cx,&format!(
                 "# Load a model and run this example in your terminal
 # Choose between streaming and non-streaming mode by setting the \"stream\" field
 
@@ -273,10 +273,10 @@ curl http://localhost:{}/v1/chat/completions \\
         } else {
             self.view
                 .view(id!(local_server_options.no_model))
-                .set_visible(true);
+                .set_visible(cx, true);
             self.view
                 .view(id!(local_server_options.main))
-                .set_visible(false);
+                .set_visible(cx, false);
         }
 
         self.view.draw_walk(cx, scope, walk)
@@ -294,9 +294,9 @@ impl WidgetMatchEvent for SettingsScreen {
                     self.override_port = None;
                 }
                 if store.chats.model_loader.is_failed() {
-                    self.view(id!(load_error_label)).set_visible(true);
+                    self.view(id!(load_error_label)).set_visible(cx, true);
                 } else {
-                    self.view(id!(load_error_label)).set_visible(false);
+                    self.view(id!(load_error_label)).set_visible(cx, false);
                 }
             }
         }
@@ -308,7 +308,7 @@ impl WidgetMatchEvent for SettingsScreen {
 
             let port = self.label(id!(port_number_label)).text();
             port_number_input.set_key_focus(cx);
-            port_number_input.set_text(&port);
+            port_number_input.set_text(cx,&port);
 
             self.redraw(cx);
         }
@@ -335,9 +335,9 @@ impl WidgetMatchEvent for SettingsScreen {
 }
 
 impl LiveHook for SettingsScreen {
-    fn after_new_from_doc(&mut self, _cx: &mut Cx) {
+    fn after_new_from_doc(&mut self, cx: &mut Cx) {
         self.view
             .view(id!(mofa_section))
-            .set_visible(moly_mofa::should_be_visible());
+            .set_visible(cx, moly_mofa::should_be_visible());
     }
 }

--- a/src/shared/download_notification_popup.rs
+++ b/src/shared/download_notification_popup.rs
@@ -277,38 +277,38 @@ impl WidgetMatchEvent for DownloadNotificationPopup {
 }
 
 impl DownloadNotificationPopup {
-    pub fn update_content(&mut self) {
+    pub fn update_content(&mut self, cx: &mut Cx) {
         match self.download_result {
-            DownloadResult::Success => self.show_success_content(),
-            DownloadResult::Failure => self.show_failure_content(),
+            DownloadResult::Success => self.show_success_content(cx),
+            DownloadResult::Failure => self.show_failure_content(cx),
         }
     }
 
-    fn show_success_content(&mut self) {
-        self.view(id!(success_icon)).set_visible(true);
-        self.view(id!(failure_icon)).set_visible(false);
+    fn show_success_content(&mut self, cx: &mut Cx) {
+        self.view(id!(success_icon)).set_visible(cx, true);
+        self.view(id!(failure_icon)).set_visible(cx, false);
 
-        self.view(id!(success_actions)).set_visible(true);
-        self.view(id!(failure_actions)).set_visible(false);
+        self.view(id!(success_actions)).set_visible(cx, true);
+        self.view(id!(failure_actions)).set_visible(cx, false);
 
         self.label(id!(title))
-            .set_text("Model Downloaded Successfully");
+            .set_text(cx,"Model Downloaded Successfully");
 
         self.label(id!(summary))
-            .set_text(&(format!("{} successfuly downloaded.", &self.filename)));
+            .set_text(cx,&(format!("{} successfuly downloaded.", &self.filename)));
     }
 
-    fn show_failure_content(&mut self) {
-        self.view(id!(success_icon)).set_visible(false);
-        self.view(id!(failure_icon)).set_visible(true);
+    fn show_failure_content(&mut self, cx: &mut Cx) {
+        self.view(id!(success_icon)).set_visible(cx, false);
+        self.view(id!(failure_icon)).set_visible(cx, true);
 
-        self.view(id!(success_actions)).set_visible(false);
-        self.view(id!(failure_actions)).set_visible(true);
+        self.view(id!(success_actions)).set_visible(cx, false);
+        self.view(id!(failure_actions)).set_visible(cx, true);
 
         self.label(id!(title))
-            .set_text("Errors while downloading models");
+            .set_text(cx,"Errors while downloading models");
 
-        self.label(id!(summary)).set_text(
+        self.label(id!(summary)).set_text(cx,
             &(format!(
                 "{} encountered some errors when downloading.",
                 &self.filename
@@ -316,29 +316,29 @@ impl DownloadNotificationPopup {
         );
     }
 
-    pub fn show_retry_content(&mut self) {
+    pub fn show_retry_content(&mut self, cx: &mut Cx) {
 
         let content = self.label(id!(summary));
-        self.view(id!(success_icon)).set_visible(false);
-        self.view(id!(failure_icon)).set_visible(true);
+        self.view(id!(success_icon)).set_visible(cx, false);
+        self.view(id!(failure_icon)).set_visible(cx, true);
 
-        self.view(id!(success_actions)).set_visible(false);
-        self.view(id!(failure_actions)).set_visible(false);
+        self.view(id!(success_actions)).set_visible(cx, false);
+        self.view(id!(failure_actions)).set_visible(cx, false);
 
         self.label(id!(title))
-            .set_text("Retry");
+            .set_text(cx,"Retry");
 
         match self.count {
             0 => {
-                content.set_text("Download interrupted. Will resume in 15 seconds.");
+                content.set_text(cx,"Download interrupted. Will resume in 15 seconds.");
                 self.count += 1;
             },
             1 => {
-                content.set_text("Download interrupted. Will resume in 30 seconds.");
+                content.set_text(cx,"Download interrupted. Will resume in 30 seconds.");
                 self.count += 1;
             },
             2 => {
-                content.set_text("Download interrupted. Will resume in 60 seconds.");
+                content.set_text(cx,"Download interrupted. Will resume in 60 seconds.");
                 self.count += 1;
             },
             _ => {
@@ -349,19 +349,19 @@ impl DownloadNotificationPopup {
 }
 
 impl DownloadNotificationPopupRef {
-    pub fn set_data(&mut self, file: &File, download_result: DownloadResult) {
+    pub fn set_data(&mut self, cx: &mut Cx, file: &File, download_result: DownloadResult) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.file_id = Some(file.id.clone());
             inner.filename = file.name.clone();
             inner.download_result = download_result;
 
-            inner.update_content();
+            inner.update_content(cx);
         }
     }
 
-    pub fn set_retry_data(&mut self) {
+    pub fn set_retry_data(&mut self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.show_retry_content();
+            inner.show_retry_content(cx);
         }
     }
 }

--- a/src/shared/tooltip.rs
+++ b/src/shared/tooltip.rs
@@ -96,8 +96,8 @@ impl Widget for Tooltip {
         DrawStep::done()
     }
 
-    fn set_text(&mut self, text: &str) {
-        self.label(id!(tooltip_label)).set_text(text);
+    fn set_text(&mut self, cx: &mut Cx, text: &str) {
+        self.label(id!(tooltip_label)).set_text(cx,text);
     }
 }
 
@@ -117,7 +117,7 @@ impl Tooltip {
     }
 
     pub fn show_with_options(&mut self, cx: &mut Cx, pos: DVec2, text: &str) {
-        self.set_text(text);
+        self.set_text(cx,text);
         self.set_pos(cx, pos);
         self.show(cx);
     }
@@ -129,9 +129,9 @@ impl Tooltip {
 }
 
 impl TooltipRef {
-    pub fn set_text(&mut self, text: &str) {
+    pub fn set_text(&mut self, cx: &mut Cx, text: &str) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.set_text(text);
+            inner.set_text(cx,text);
         }
     }
 


### PR DESCRIPTION
The changes are many yet they are quite simple:
- `set_text()` now takes `cx` to automatically request a redraw, same for `set_visible`, and `set_value` on some widgets.
- `set_text_and_redraw()` no longer exists.