### PR TITLE
Tiny fixes + Chat hooks rework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["packaging/before-packaging-command"]
 name = "moly"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.79"                                                 ## required by cargo-packager
+rust-version = "1.81"                                                 ## required by cargo-packager
 description = "Desktop app for downloading and chatting with AI LLMs"
 
 ## Rename the binary to `_moly_app` to avoid naming conflicts

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -1,7 +1,6 @@
 use futures::{stream::AbortHandle, StreamExt};
 use makepad_widgets::*;
 use std::cell::{Ref, RefMut};
-use std::sync::RwLock;
 use utils::asynchronous::spawn;
 
 use crate::utils::events::EventExt;
@@ -22,57 +21,16 @@ live_design!(
     }
 );
 
-/// Private action that carries a [ChatHook] for a [Chat] widget.
-#[derive(Debug)]
-struct ChatAction {
-    hook: RwLock<ChatHook>,
-    // A widget action is more strict than an action as it needs to implement `ActionDefaultRef`,
-    // so this will keep things simple here inside.
-    widget_uid: WidgetUid,
-}
-
-/// Encapsulates a set of [ChatTask]s that can me modified before being executed
-/// by the [Chat] widget.
-#[derive(Debug)]
-pub struct ChatHook {
-    executed: bool,
-    tasks: Option<Vec<ChatTask>>,
-}
-
-impl ChatHook {
-    /// Aborts the set of tasks contained by this hook.
-    ///
-    /// Further calls to `tasks` and `hook` in the [Chat] widget will have no
-    /// effect.
-    ///
-    /// Trying to access tasks through this hook after aborting will panic.
-    pub fn abort(&mut self) {
-        self.tasks = None;
-    }
-
-    /// Immutable slice over the tasks in this hook.
-    pub fn tasks(&self) -> &[ChatTask] {
-        self.tasks
-            .as_ref()
-            .expect("the task in this hook has been aborted")
-    }
-
-    /// Mutable reference to the tasks in this hook.
-    pub fn tasks_mut(&mut self) -> &mut Vec<ChatTask> {
-        self.tasks
-            .as_mut()
-            .expect("the task in this hook has been aborted")
-    }
-}
-
 /// A task of interest that was or will be performed by the [Chat] widget depending
-/// on if you read it before the chat widget receives it back or not.
+/// on xxxxxxxxx
+///
+/// TODO: Fix this documentation.
 ///
 /// The payload in this task will be used to perform the task itself. If you have
 /// access to its wrapper [ChatHook], you can modify the task before it is executed.
 ///
-/// See [Chat::tasks] and [Chat::hook] for more information.
-// TODO: Using indexes for many uperation like `UpdateMessage` is not ideal. In the future
+/// See xxxxxxx for more information.
+// TODO: Using indexes for many operations like `UpdateMessage` is not ideal. In the future
 // messages may need to have a unique identifier.
 #[derive(Debug)]
 pub enum ChatTask {
@@ -95,7 +53,7 @@ pub enum ChatTask {
     DeleteMessage(usize),
 
     /// When received back, it will update the message at the given index with the given text.
-    UpdateMessage(usize, String),
+    UpdateMessage(usize, Message),
 
     /// When received back, it will clear the prompt input.
     ClearPrompt,
@@ -107,75 +65,6 @@ pub enum ChatTask {
 impl From<ChatTask> for Vec<ChatTask> {
     fn from(task: ChatTask) -> Self {
         vec![task]
-    }
-}
-
-/// An intermidiate type that can read [ChatTask] from an [Event].
-///
-/// Avoids retaining [Chat] self reference during closure execution.
-pub struct ChatTaskReader<'e> {
-    event: &'e Event,
-    widget_uid: WidgetUid,
-}
-
-impl<'e> ChatTaskReader<'e> {
-    /// Construct a new [ChatTaskReader]. Prefer using [Chat::tasks] instead.
-    fn new(widget_uid: WidgetUid, event: &'e Event) -> Self {
-        Self { widget_uid, event }
-    }
-
-    /// Read the tasks from the event.
-    pub fn read_with(&self, mut reader: impl FnMut(&ChatTask)) {
-        for action in chat_actions(self.widget_uid, self.event) {
-            let hook = action.hook.read().expect("the task is being hooked");
-            let Some(tasks) = &hook.tasks else {
-                return;
-            };
-            for task in tasks {
-                reader(task);
-            }
-        }
-    }
-}
-
-/// An intermidiate type that can read/write [ChatHook] in an [Event].
-///
-/// Avoids retaining [Chat] self reference during closure execution.
-pub struct ChatHookWriter<'e> {
-    event: &'e Event,
-    widget_uid: WidgetUid,
-}
-
-impl<'e> ChatHookWriter<'e> {
-    /// Construct a new [ChatHookWriter]. Prefer using [Chat::hook] instead.
-    fn new(widget_uid: WidgetUid, event: &'e Event) -> Self {
-        Self { widget_uid, event }
-    }
-
-    /// Get write access to hooks in this event.
-    pub fn write_with(&self, mut hook_fn: impl FnMut(&mut ChatHook)) {
-        for action in chat_actions(self.widget_uid, self.event) {
-            {
-                // let's use `read` first to avoid panicking before other checks
-                let hook = action.hook.read().expect("the task is being hooked");
-
-                if hook.tasks.is_none() {
-                    return;
-                }
-
-                if hook.executed {
-                    panic!(
-                        "Hooking into a chat task that has already been executed. \
-                        Changes to the task would not have effect so this is invalid. \
-                        If you are trying to read the task without changing it, use `tasks` instead. \
-                        If you are trying to change the task, you should do it before `Chat`'s `handle_event`."
-                    );
-                }
-            }
-
-            let mut hook = action.hook.write().expect("the task is being hooked");
-            hook_fn(&mut *hook);
-        }
     }
 }
 
@@ -202,6 +91,15 @@ pub struct Chat {
 
     #[rust]
     abort_handle: Option<AbortHandle>,
+
+    #[rust]
+    hook_before: Option<Box<dyn FnMut(&mut Vec<ChatTask>, &mut Chat, &mut Cx)>>,
+
+    #[rust]
+    hook_after: Option<Box<dyn FnMut(&[ChatTask], &mut Chat, &mut Cx)>>,
+
+    #[rust]
+    is_hooking: bool,
 }
 
 impl Widget for Chat {
@@ -215,7 +113,6 @@ impl Widget for Chat {
 
         self.ui_runner().handle(cx, event, scope, self);
         self.deref.handle_event(cx, event, scope);
-        self.handle_tasks(cx, event);
         self.handle_messages(cx, event);
         self.handle_prompt_input(cx, event);
     }
@@ -254,27 +151,32 @@ impl Chat {
 
             match action.cast::<MessagesAction>() {
                 MessagesAction::Delete(index) => {
-                    self.dispatch(cx, ChatTask::DeleteMessage(index).into());
+                    self.dispatch(cx, &mut ChatTask::DeleteMessage(index).into());
                 }
                 MessagesAction::Copy(index) => {
-                    self.dispatch(cx, ChatTask::CopyMessage(index).into());
+                    self.dispatch(cx, &mut ChatTask::CopyMessage(index).into());
                 }
                 MessagesAction::EditSave(index) => {
-                    self.messages_ref().read_with(|m| {
-                        let text = m.current_editor_text().expect("no editor text");
-                        self.dispatch(cx, ChatTask::UpdateMessage(index, text).into());
+                    let mut tasks = self.messages_ref().read_with(|m| {
+                        let mut message = m.messages[index].clone();
+                        message.body = m.current_editor_text().expect("no editor text");
+                        ChatTask::UpdateMessage(index, message).into()
                     });
+
+                    self.dispatch(cx, &mut tasks);
                 }
                 MessagesAction::EditRegenerate(index) => {
-                    self.messages_ref().read_with(|m| {
+                    let mut tasks = self.messages_ref().read_with(|m| {
                         let mut messages = m.messages[0..=index].to_vec();
 
                         let index = m.current_editor_index().expect("no editor index");
                         let text = m.current_editor_text().expect("no editor text");
 
                         messages[index].body = text;
-                        self.dispatch(cx, vec![ChatTask::SetMessages(messages), ChatTask::Send]);
+                        vec![ChatTask::SetMessages(messages), ChatTask::Send]
                     });
+
+                    self.dispatch(cx, &mut tasks);
                 }
                 MessagesAction::None => {}
             }
@@ -303,9 +205,9 @@ impl Chat {
 
             composition.extend([ChatTask::Send, ChatTask::ClearPrompt]);
 
-            self.dispatch(cx, composition);
+            self.dispatch(cx, &mut composition);
         } else if prompt.read().has_stop_task() {
-            self.dispatch(cx, ChatTask::Stop.into());
+            self.dispatch(cx, &mut ChatTask::Stop.into());
         }
     }
 
@@ -329,8 +231,6 @@ impl Chat {
                 citations: vec![],
             });
 
-            self.dispatch(cx, ChatTask::ScrollToBottom.into());
-
             messages
                 .messages
                 .iter()
@@ -339,6 +239,7 @@ impl Chat {
                 .collect()
         });
 
+        self.dispatch(cx, &mut ChatTask::ScrollToBottom.into());
         self.prompt_input_ref().write().set_stop();
         self.redraw(cx);
 
@@ -357,23 +258,30 @@ impl Chat {
                 };
 
                 ui.defer_with_redraw(move |me, cx, _scope| {
-                    me.messages_ref().write_with(|messages| {
-                        let last_index = messages.messages.len() - 1;
-                        let message = messages.messages.last_mut().expect("no message where to put delta");
+                    let (index, message, is_at_bottom) = me.messages_ref().read_with(|messages| {
+                        let mut message = messages
+                            .messages
+                            .last()
+                            .expect("no message where to put delta")
+                            .clone();
 
-                        // Append new text
                         message.body.push_str(&delta.content_delta);
+                        message
+                            .citations
+                            .extend(delta.citations.unwrap_or_default());
 
-                        // If the chunk contains citations, store them
-                        if let Some(cits) = &delta.citations {
-                            message.citations = cits.clone();
-                        }
-
-                        me.dispatch(cx, ChatTask::UpdateMessage(last_index, message.body.clone()).into());
-                        if messages.is_at_bottom() {
-                            me.dispatch(cx, ChatTask::ScrollToBottom.into());
-                        }
+                        (
+                            messages.messages.len() - 1,
+                            message,
+                            messages.is_at_bottom(),
+                        )
                     });
+
+                    me.dispatch(cx, &mut ChatTask::UpdateMessage(index, message).into());
+
+                    if is_at_bottom {
+                        me.dispatch(cx, &mut ChatTask::ScrollToBottom.into());
+                    }
                 });
             }
 
@@ -408,54 +316,42 @@ impl Chat {
     /// Dispatch a set of tasks to be executed by the [Chat] widget as a single hookable
     /// unit of work.
     ///
-    /// You can still hook into the task before it's executed for real, see [Chat::hook].
-    pub fn dispatch(&self, cx: &mut Cx, tasks: Vec<ChatTask>) {
-        let action = ChatAction {
-            hook: RwLock::new(ChatHook {
-                executed: false,
-                tasks: Some(tasks),
-            }),
-            widget_uid: self.widget_uid(),
-        };
+    /// You can still hook into the task before it's executed for real.
+    pub fn dispatch(&mut self, cx: &mut Cx, tasks: &mut Vec<ChatTask>) {
+        self.is_hooking = true;
 
-        cx.action(action);
+        if let Some(mut hook) = self.hook_before.take() {
+            hook(tasks, self, cx);
+            self.hook_before = Some(hook);
+        }
+
+        for task in tasks.iter() {
+            // TODO: Okey, this is what is causing the runtime borrow explosion.
+            // now that this is immediate, it will explose because other dispatching stuff
+            // will keep holding stuff.
+            // I should delay dispatch processing to be executed at the end of specific places
+            // like handle event to mimic the old behavior.
+            self.handle_task(cx, task);
+        }
+
+        if let Some(mut hook) = self.hook_after.take() {
+            hook(tasks, self, cx);
+            self.hook_after = Some(hook);
+        }
+
+        self.is_hooking = false;
     }
 
     /// Performs a set of tasks in the [Chat] widget immediately.
     ///
-    /// This is not hookable, no actions are emitted from this.
+    /// This is not hookable.
     pub fn perform(&mut self, cx: &mut Cx, tasks: &[ChatTask]) {
         for task in tasks {
-            self.handle_primitive_task(cx, &task);
+            self.handle_task(cx, &task);
         }
     }
 
-    /// Get a reader to each [ChatTask] available in the event.
-    ///
-    /// This yields individual tasks and not the whole set of tasks in the underlying hook.
-    pub fn tasks<'e>(&self, event: &'e Event) -> ChatTaskReader<'e> {
-        ChatTaskReader::new(self.widget_uid(), event)
-    }
-
-    /// Get a writer to the [ChatHook] in the event.
-    ///
-    /// With this you can abort a set of tasks, or modify them before they are executed.
-    ///
-    /// See [ChatHook] for more information.
-    pub fn hook<'e>(&self, event: &'e Event) -> ChatHookWriter<'e> {
-        ChatHookWriter::new(self.widget_uid(), event)
-    }
-
-    fn handle_tasks(&mut self, cx: &mut Cx, event: &Event) {
-        self.hook(event).write_with(|hook| {
-            hook.executed = true;
-            if let Some(tasks) = hook.tasks.as_mut() {
-                self.perform(cx, tasks);
-            }
-        });
-    }
-
-    fn handle_primitive_task(&mut self, cx: &mut Cx, task: &ChatTask) {
+    fn handle_task(&mut self, cx: &mut Cx, task: &ChatTask) {
         match task {
             ChatTask::CopyMessage(index) => {
                 self.messages_ref().read_with(|m| {
@@ -468,10 +364,10 @@ impl Chat {
                 self.redraw(cx);
             }
             ChatTask::InsertMessage(index, message) => {
-                self.messages_ref().write().messages.insert(
-                    *index,
-                    message.clone(),
-                );
+                self.messages_ref()
+                    .write()
+                    .messages
+                    .insert(*index, message.clone());
                 self.redraw(cx);
             }
             ChatTask::Send => {
@@ -480,9 +376,9 @@ impl Chat {
             ChatTask::Stop => {
                 self.perform_stop(cx);
             }
-            ChatTask::UpdateMessage(index, text) => {
+            ChatTask::UpdateMessage(index, message) => {
                 self.messages_ref().write_with(|m| {
-                    m.messages[*index].body = text.clone();
+                    m.messages[*index] = message.clone();
                     m.set_message_editor_visibility(*index, false);
                 });
 
@@ -507,17 +403,25 @@ impl Chat {
             }
         }
     }
-}
 
-fn chat_actions<'e>(
-    widget_uid: WidgetUid,
-    event: &'e Event,
-) -> impl Iterator<Item = &'e ChatAction> + 'e {
-    event
-        .actions()
-        .iter()
-        .filter_map(|a| a.downcast_ref::<ChatAction>())
-        .filter(move |a| a.widget_uid == widget_uid)
+    pub fn set_hook_before(
+        &mut self,
+        hook: impl FnMut(&mut Vec<ChatTask>, &mut Chat, &mut Cx) + 'static,
+    ) {
+        if self.is_hooking {
+            panic!("Cannot set a hook while hooking");
+        }
+
+        self.hook_before = Some(Box::new(hook));
+    }
+
+    pub fn set_hook_after(&mut self, hook: impl FnMut(&[ChatTask], &mut Chat, &mut Cx) + 'static) {
+        if self.is_hooking {
+            panic!("Cannot set a hook while hooking");
+        }
+
+        self.hook_after = Some(Box::new(hook));
+    }
 }
 
 // TODO: Since `ChatRef` is generated by a macro, I can't document this to give

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -43,7 +43,7 @@ impl Widget for DemoChat {
             chat.hook(event).write_with(|hook| {
                 let mut abort = false;
 
-                for task in hook.tasks() {
+                for task in hook.tasks_mut() {
                     if let ChatTask::CopyMessage(index) = task {
                         abort = true;
 
@@ -53,6 +53,14 @@ impl Widget for DemoChat {
                         });
 
                         cx.copy_to_clipboard(&text);
+                    }
+
+                    if let ChatTask::UpdateMessage(_index, message) = task {
+                        message.body = message.body.replace("ello", "3110 (hooked)");
+
+                        if message.body.contains("bad word") {
+                            abort = true;
+                        }
                     }
                 }
 
@@ -69,8 +77,8 @@ impl Widget for DemoChat {
         // after `handle_event`.
         chat.read_with(|chat| {
             chat.tasks(event).read_with(|task| {
-                if let ChatTask::UpdateMessage(index, body) = task {
-                    log!("Message updated at index {}: {}", index, body);
+                if let ChatTask::UpdateMessage(index, message) = task {
+                    log!("Message updated at index {}: {}", index, message.body);
                 }
             });
         });

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -56,6 +56,7 @@ impl Widget for DemoChat {
 
 impl LiveHook for DemoChat {
     fn after_new_from_doc(&mut self, _cx: &mut Cx) {
+        // Setup some hooks as an example of how to use them.
         self.setup_chat_hooks();
         self.setup_chat_repo();
     }


### PR DESCRIPTION
# Changes

- Require Rust 1.81
- Chat tasks are executed/applied immediately instead of going through makepad's actions.
  - This solves issues with tasks requiring to have always up to date state on the widgets and users hooking expecting the same.
  - The hooking system now uses callbacks that can be set to modify tasks just before they are executed, or to just get notified after they occurred.
    - You can still access the widget inside the hook with an `UiRunner` or communicating with raw makepad actions.