### PR TITLE
MolyKit tiny cleanup

### DIFF
--- a/moly-kit/src/clients/moly.rs
+++ b/moly-kit/src/clients/moly.rs
@@ -88,7 +88,7 @@ struct Choice {
 struct Completion {
     pub choices: Vec<Choice>,
     #[serde(default)]
-    pub citations: Option<Vec<String>>,
+    pub citations: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -194,7 +194,7 @@ impl BotClient for MolyClient {
         &mut self,
         bot: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, Result<ChatDelta, ()>> {
+    ) -> MolyStream<'static, Result<MessageDelta, ()>> {
         let moly_messages: Vec<OutcomingMessage> = messages
             .iter()
             .filter_map(|m| m.clone().try_into().ok())
@@ -268,17 +268,16 @@ impl BotClient for MolyClient {
                         }
                     };
 
-                    // Combine all partial choices content
-                    let content_delta = completion
+                    let body = completion
                         .choices
                         .iter()
                         .map(|c| c.delta.content.as_str())
                         .collect::<String>();
 
-                    let citations = completion.citations.clone();
+                    let citations = completion.citations;
 
-                    yield Ok(ChatDelta {
-                        content_delta,
+                    yield Ok(MessageDelta {
+                        body,
                         citations,
                     });
                 }

--- a/moly-kit/src/clients/multi.rs
+++ b/moly-kit/src/clients/multi.rs
@@ -28,7 +28,7 @@ impl BotClient for MultiClient {
         &mut self,
         bot: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, Result<ChatDelta, ()>> {
+    ) -> MolyStream<'static, Result<MessageDelta, ()>> {
         let mut client = self
             .clients_with_bots
             .lock()

--- a/moly-kit/src/widgets.rs
+++ b/moly-kit/src/widgets.rs
@@ -3,6 +3,7 @@
 //! Note: Some widgets may depend on certain feature flags.
 
 mod avatar;
+mod citations;
 mod message_loading;
 mod message_markdown;
 
@@ -17,6 +18,7 @@ pub use messages::*;
 pub use prompt_input::*;
 
 pub fn live_design(cx: &mut makepad_widgets::Cx) {
+    citations::live_design(cx);
     makepad_code_editor::live_design(cx);
     message_markdown::live_design(cx);
     message_loading::live_design(cx);

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -248,10 +248,10 @@ impl Chat {
 
             while let Some(delta) = message_stream.next().await {
                 let delta = match delta {
-                    Ok(chat_delta) => chat_delta,
-                    Err(_) => ChatDelta {
-                        content_delta: "An error occurred".to_string(),
-                        citations: None,
+                    Ok(delta) => delta,
+                    Err(_) => MessageDelta {
+                        body: "An error occurred".to_string(),
+                        ..Default::default()
                     },
                 };
 
@@ -263,10 +263,13 @@ impl Chat {
                             .expect("no message where to put delta")
                             .clone();
 
-                        message.body.push_str(&delta.content_delta);
-                        message
-                            .citations
-                            .extend(delta.citations.unwrap_or_default());
+                        message.body.push_str(&delta.body);
+                        // TODO: Maybe this is a good case for a sorted set, like `BTreeSet`.
+                        for citation in delta.citations {
+                            if !message.citations.contains(&citation) {
+                                message.citations.push(citation);
+                            }
+                        }
 
                         (
                             messages.messages.len() - 1,

--- a/moly-kit/src/widgets/citations.rs
+++ b/moly-kit/src/widgets/citations.rs
@@ -1,0 +1,302 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::utils::asynchronous::spawn;
+use makepad_widgets::*;
+use reqwest::header::{HeaderValue, USER_AGENT};
+use url_preview::{Preview, PreviewService};
+
+live_design! {
+    use link::theme::*;
+    use link::widgets::*;
+
+    BOLD_FONT = {
+        font: {path: dep("crate://makepad-widgets/resources/IBMPlexSans-SemiBold.ttf")}
+    }
+
+    LINK_ICON = dep("crate://self/assets/link.png")
+
+
+    pub Citations = {{Citations}} {
+        margin: {top: 15}
+        height: Fit, width: Fill,
+        flow: RightWrap, spacing: 10
+        // TODO: We want make these rounded but don't have a straight forward way to have the inner image match the same radius.
+        citation_template: {{LinkPreviewUI}}<RoundedView> {
+            cursor: Hand,
+            height: 75, width: 180
+            flow: Right, spacing: 5
+            show_bg: true,
+            draw_bg: {
+                color: #f2f2f2
+                radius: 0
+            }
+            align: {y: 0.5}
+            image_wrapper = <RoundedView> {
+                draw_bg: {
+                    radius: 0
+                },
+                align: {y: 0.5, x: 0.5},
+                width: 75, height: Fill,
+                visible: true,
+                image = <Image> {
+                    width: 30, height: 55,
+                    fit: Vertical,
+                    source: (LINK_ICON)
+                }
+            }
+            flow_down_wrapper = <View> {
+                flow: Down, spacing: 5
+                align: {y: 0.5, x: 0.0}
+                title = <Label> {
+                    text: "Loading..."
+                    draw_text: {
+                        text_style: <BOLD_FONT>{},
+                        color: #000
+                    }
+                }
+                domain = <Label> {
+                    text: "Loading..."
+                    draw_text: {
+                        color: #000
+                    }
+                }
+            }
+        }
+    }
+
+
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct Citations {
+    #[deref]
+    view: View,
+
+    /// The template for the citation views.
+    #[live]
+    citation_template: Option<LivePtr>,
+
+    /// The views that represent the citations.
+    #[rust]
+    link_preview_children: ComponentMap<usize, LinkPreviewUI>,
+
+    /// The citations (URLs) that are currently being rendered.
+    #[rust]
+    citations: Vec<String>,
+
+    /// Maps the index of the citation to the link preview.
+    #[rust]
+    link_previews: HashMap<usize, Preview>,
+
+    /// Maps the index of the citation to the image blob.
+    #[rust]
+    image_blobs: HashMap<usize, Vec<u8>>,
+
+    /// Track which images have already been loaded
+    #[rust]
+    loaded_image_indices: HashSet<usize>,
+}
+
+impl Widget for Citations {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.ui_runner().handle(cx, event, scope, self);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        // TODO: Fix this, currently redrawing on every event
+        // And at the same time, the citations are not being redrawn unless there's a user-triggered event like mouse move or window resize.
+        cx.begin_turtle(walk, self.layout);
+        for (citation_id, citation) in self.link_preview_children.iter_mut() {
+            let citation_content = &self.citations[*citation_id];
+            let domain = url::Url::parse(citation_content)
+                .ok()
+                .and_then(|u| u.domain().map(|d| d.to_string()))
+                .unwrap_or_default();
+            citation.url = citation_content.clone();
+            citation.label(id!(domain)).set_text(cx, &domain);
+
+            if let Some(link_preview) = self.link_previews.get(citation_id) {
+                if let Some(title) = &link_preview.title {
+                    citation.label(id!(title)).set_text(cx, &title);
+                }
+                if link_preview.image_url.is_some() {
+                    if let Some(image_bytes) = self.image_blobs.get(citation_id) {
+                        // Only load image if it's not already loaded
+                        if !self.loaded_image_indices.contains(citation_id) {
+                            if is_jpeg(image_bytes) {
+                                let _ = citation
+                                    .image(id!(image))
+                                    .load_jpg_from_data(cx, &image_bytes);
+                                citation.image(id!(image)).apply_over(
+                                    cx,
+                                    live! {
+                                        width: 75, height: 75
+                                    },
+                                );
+                            } else if is_png(image_bytes) {
+                                citation.image(id!(image)).apply_over(
+                                    cx,
+                                    live! {
+                                        width: 75, height: 75
+                                    },
+                                );
+                                let _ = citation
+                                    .image(id!(image))
+                                    .load_png_from_data(cx, &image_bytes);
+                            } else {
+                                // TODO: handle other image types
+                                // Do not try again
+                                self.loaded_image_indices.insert(*citation_id);
+                            }
+                            self.loaded_image_indices.insert(*citation_id);
+                        }
+                    }
+                }
+            }
+            while citation.draw(cx, scope).step().is_some() {}
+        }
+        cx.end_turtle();
+        DrawStep::done()
+    }
+}
+
+impl Citations {
+    fn save_link_preview(&mut self, index: usize, link_preview: Preview) {
+        let image_url = link_preview.image_url.clone();
+        self.link_previews.insert(index, link_preview);
+        // Only fetch if we don't already have this image
+        if let Some(image_url) = image_url {
+            if !self.image_blobs.contains_key(&index) {
+                let ui = self.ui_runner();
+                spawn(async move {
+                    let fetched_image = fetch_image_blob(&image_url).await;
+                    if let Ok(image_bytes) = fetched_image {
+                        ui.defer_with_redraw(move |me, _cx, _scope| {
+                            me.image_blobs.insert(index, image_bytes);
+                        });
+                    }
+                });
+            }
+        }
+    }
+
+    fn update_citations(&mut self, cx: &mut Cx, citations: &Vec<String>) {
+        self.visible = true;
+        // compare the vecs, if they are the same, return
+        if self.citations.len() == citations.len() {
+            let is_same = self
+                .citations
+                .iter()
+                .zip(citations.iter())
+                .all(|(a, b)| a == b);
+            if is_same {
+                return;
+            }
+        }
+
+        self.citations = citations.clone();
+        self.visible = true;
+        self.link_preview_children.clear();
+        self.loaded_image_indices.clear();
+        self.image_blobs.clear();
+
+        for (index, citation) in citations.iter().enumerate() {
+            let new_citation = LinkPreviewUI::new_from_ptr(cx, self.citation_template);
+            self.link_preview_children.insert(index, new_citation);
+
+            let citation_clone = citation.clone();
+            let index_clone = index;
+            let ui = self.ui_runner();
+
+            // TODO: rework this to use caching and batch fetching from the url-preview crate.
+            spawn(async move {
+                let future = async {
+                    let preview = PreviewService::new()
+                        .generate_preview(&citation_clone)
+                        .await;
+                    match preview {
+                        Ok(preview) => {
+                            ui.defer_with_redraw(move |me, _cx, _scope| {
+                                me.save_link_preview(index_clone, preview);
+                            });
+                        }
+                        Err(e) => {
+                            eprintln!("Error fetching preview for index {}: {:?}", index_clone, e);
+                        }
+                    }
+                };
+
+                let (future, _abort_handle) = futures::future::abortable(future);
+                future.await.unwrap_or_else(|_| {
+                    eprintln!("Preview fetch aborted for index {}", index_clone)
+                });
+            });
+        }
+
+        self.redraw(cx);
+    }
+}
+
+impl CitationsRef {
+    pub fn set_citations(&mut self, cx: &mut Cx, citations: &Vec<String>) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.update_citations(cx, citations);
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct LinkPreviewUI {
+    #[deref]
+    view: View,
+
+    #[rust]
+    url: String,
+}
+
+impl Widget for LinkPreviewUI {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for LinkPreviewUI {
+    fn handle_actions(&mut self, _cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        // TODO: these finger up events are not reaching here.
+        if let Some(item) = actions.find_widget_action(self.widget_uid()) {
+            if let ViewAction::FingerUp(_fd) = item.cast() {
+                // TODO: This should check for `was_tap` right?
+                let _ = robius_open::Uri::new(&self.url).open();
+            }
+        }
+    }
+}
+
+async fn fetch_image_blob(url: &str) -> Result<Vec<u8>, reqwest::Error> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(url)
+        // Trick the server into thinking we're a browser
+        .header(USER_AGENT, HeaderValue::from_static(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+        ))
+        .send()
+        .await?;
+
+    let bytes = response.bytes().await?;
+    Ok(bytes.to_vec())
+}
+
+fn is_jpeg(bytes: &[u8]) -> bool {
+    bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8
+}
+
+fn is_png(bytes: &[u8]) -> bool {
+    bytes.len() >= 4 && bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47
+}

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -1,16 +1,13 @@
-use std::{
-    cell::{Ref, RefMut},
-    collections::{HashMap, HashSet},
-};
+use std::cell::{Ref, RefMut};
 
 use crate::{
     protocol::*,
-    utils::{asynchronous::spawn, events::EventExt, portal_list::ItemsRangeIter},
+    utils::{events::EventExt, portal_list::ItemsRangeIter},
     widgets::{avatar::AvatarWidgetRefExt, message_loading::MessageLoadingWidgetRefExt},
 };
 use makepad_widgets::*;
-use reqwest::header::{HeaderValue, USER_AGENT};
-use url_preview::{Preview, PreviewService};
+
+use super::citations::CitationsWidgetRefExt;
 
 live_design! {
     use link::theme::*;
@@ -20,11 +17,11 @@ live_design! {
     use crate::widgets::message_markdown::*;
     use crate::widgets::message_loading::*;
     use crate::widgets::avatar::*;
+    use crate::widgets::citations::*;
 
     BOLD_FONT = {
         font: {path: dep("crate://makepad-widgets/resources/IBMPlexSans-SemiBold.ttf")}
     }
-    LINK_ICON = dep("crate://self/assets/link.png")
 
     Sender = <View> {
         height: Fit,
@@ -99,54 +96,6 @@ live_design! {
             empty_message: "\n",
             draw_text: {
                 color: #000
-            }
-        }
-    }
-
-    Citations = {{Citations}} {
-        margin: {top: 15}
-        height: Fit, width: Fill,
-        flow: RightWrap, spacing: 10
-        // TODO: We want make these rounded but don't have a straight forward way to have the inner image match the same radius.
-        citation_template: {{LinkPreviewUI}}<RoundedView> {
-            cursor: Hand,
-            height: 75, width: 180
-            flow: Right, spacing: 5
-            show_bg: true,
-            draw_bg: {
-                color: #f2f2f2
-                radius: 0
-            }
-            align: {y: 0.5}
-            image_wrapper = <RoundedView> {
-                draw_bg: {
-                    radius: 0
-                },
-                align: {y: 0.5, x: 0.5},
-                width: 75, height: Fill,
-                visible: true,
-                image = <Image> {
-                    width: 30, height: 55,
-                    fit: Vertical,
-                    source: (LINK_ICON)
-                }
-            }
-            flow_down_wrapper = <View> {
-                flow: Down, spacing: 5
-                align: {y: 0.5, x: 0.0}
-                title = <Label> {
-                    text: "Loading..."
-                    draw_text: {
-                        text_style: <BOLD_FONT>{},
-                        color: #000
-                    }
-                }
-                domain = <Label> {
-                    text: "Loading..."
-                    draw_text: {
-                        color: #000
-                    }
-                }
             }
         }
     }
@@ -631,238 +580,4 @@ impl MessagesRef {
     pub fn write_with<R>(&mut self, f: impl FnOnce(&mut Messages) -> R) -> R {
         f(&mut *self.write())
     }
-}
-
-#[derive(Live, LiveHook, Widget)]
-pub struct Citations {
-    #[deref]
-    view: View,
-
-    /// The template for the citation views.
-    #[live]
-    citation_template: Option<LivePtr>,
-
-    /// The views that represent the citations.
-    #[rust]
-    link_preview_children: ComponentMap<usize, LinkPreviewUI>,
-
-    /// The citations (URLs) that are currently being rendered.
-    #[rust]
-    citations: Vec<String>,
-
-    /// Maps the index of the citation to the link preview.
-    #[rust]
-    link_previews: HashMap<usize, Preview>,
-
-    /// Maps the index of the citation to the image blob.
-    #[rust]
-    image_blobs: HashMap<usize, Vec<u8>>,
-
-    /// Track which images have already been loaded
-    #[rust]
-    loaded_image_indices: HashSet<usize>,
-}
-
-impl Widget for Citations {
-    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        self.view.handle_event(cx, event, scope);
-        self.ui_runner().handle(cx, event, scope, self);
-    }
-
-    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        // TODO: Fix this, currently redrawing on every event
-        // And at the same time, the citations are not being redrawn unless there's a user-triggered event like mouse move or window resize.
-        cx.begin_turtle(walk, self.layout);
-        for (citation_id, citation) in self.link_preview_children.iter_mut() {
-            let citation_content = &self.citations[*citation_id];
-            let domain = url::Url::parse(citation_content)
-                .ok()
-                .and_then(|u| u.domain().map(|d| d.to_string()))
-                .unwrap_or_default();
-            citation.url = citation_content.clone();
-            citation.label(id!(domain)).set_text(cx, &domain);
-
-            if let Some(link_preview) = self.link_previews.get(citation_id) {
-                if let Some(title) = &link_preview.title {
-                    citation.label(id!(title)).set_text(cx, &title);
-                }
-                if link_preview.image_url.is_some() {
-                    if let Some(image_bytes) = self.image_blobs.get(citation_id) {
-                        // Only load image if it's not already loaded
-                        if !self.loaded_image_indices.contains(citation_id) {
-                            if is_jpeg(image_bytes) {
-                                let _ = citation
-                                    .image(id!(image))
-                                    .load_jpg_from_data(cx, &image_bytes);
-                                citation.image(id!(image)).apply_over(
-                                    cx,
-                                    live! {
-                                        width: 75, height: 75
-                                    },
-                                );
-                            } else if is_png(image_bytes) {
-                                citation.image(id!(image)).apply_over(
-                                    cx,
-                                    live! {
-                                        width: 75, height: 75
-                                    },
-                                );
-                                let _ = citation
-                                    .image(id!(image))
-                                    .load_png_from_data(cx, &image_bytes);
-                            } else {
-                                // TODO: handle other image types
-                                // Do not try again
-                                self.loaded_image_indices.insert(*citation_id);
-                            }
-                            self.loaded_image_indices.insert(*citation_id);
-                        }
-                    }
-                }
-            }
-            while citation.draw(cx, scope).step().is_some() {}
-        }
-        cx.end_turtle();
-        DrawStep::done()
-    }
-}
-
-impl Citations {
-    fn save_link_preview(&mut self, index: usize, link_preview: Preview) {
-        let image_url = link_preview.image_url.clone();
-        self.link_previews.insert(index, link_preview);
-        // Only fetch if we don't already have this image
-        if let Some(image_url) = image_url {
-            if !self.image_blobs.contains_key(&index) {
-                let ui = self.ui_runner();
-                spawn(async move {
-                    let fetched_image = fetch_image_blob(&image_url).await;
-                    if let Ok(image_bytes) = fetched_image {
-                        ui.defer_with_redraw(move |me, _cx, _scope| {
-                            me.image_blobs.insert(index, image_bytes);
-                        });
-                    }
-                });
-            }
-        }
-    }
-
-    fn update_citations(&mut self, cx: &mut Cx, citations: &Vec<String>) {
-        self.visible = true;
-        // compare the vecs, if they are the same, return
-        if self.citations.len() == citations.len() {
-            let is_same = self
-                .citations
-                .iter()
-                .zip(citations.iter())
-                .all(|(a, b)| a == b);
-            if is_same {
-                return;
-            }
-        }
-
-        self.citations = citations.clone();
-        self.visible = true;
-        self.link_preview_children.clear();
-        self.loaded_image_indices.clear();
-        self.image_blobs.clear();
-
-        for (index, citation) in citations.iter().enumerate() {
-            let new_citation = LinkPreviewUI::new_from_ptr(cx, self.citation_template);
-            self.link_preview_children.insert(index, new_citation);
-
-            let citation_clone = citation.clone();
-            let index_clone = index;
-            let ui = self.ui_runner();
-
-            // TODO: rework this to use caching and batch fetching from the url-preview crate.
-            spawn(async move {
-                let future = async {
-                    let preview = PreviewService::new()
-                        .generate_preview(&citation_clone)
-                        .await;
-                    match preview {
-                        Ok(preview) => {
-                            ui.defer_with_redraw(move |me, _cx, _scope| {
-                                me.save_link_preview(index_clone, preview);
-                            });
-                        }
-                        Err(e) => {
-                            eprintln!("Error fetching preview for index {}: {:?}", index_clone, e);
-                        }
-                    }
-                };
-
-                let (future, _abort_handle) = futures::future::abortable(future);
-                future.await.unwrap_or_else(|_| {
-                    eprintln!("Preview fetch aborted for index {}", index_clone)
-                });
-            });
-        }
-
-        self.redraw(cx);
-    }
-}
-
-impl CitationsRef {
-    fn set_citations(&mut self, cx: &mut Cx, citations: &Vec<String>) {
-        if let Some(mut inner) = self.borrow_mut() {
-            inner.update_citations(cx, citations);
-        }
-    }
-}
-
-#[derive(Live, LiveHook, Widget)]
-pub struct LinkPreviewUI {
-    #[deref]
-    view: View,
-
-    #[rust]
-    url: String,
-}
-
-impl Widget for LinkPreviewUI {
-    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        self.view.handle_event(cx, event, scope);
-        self.widget_match_event(cx, event, scope);
-    }
-
-    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        self.view.draw_walk(cx, scope, walk)
-    }
-}
-
-impl WidgetMatchEvent for LinkPreviewUI {
-    fn handle_actions(&mut self, _cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        // TODO: these finger up events are not reaching here.
-        if let Some(item) = actions.find_widget_action(self.widget_uid()) {
-            if let ViewAction::FingerUp(_fd) = item.cast() {
-                // TODO: This should check for `was_tap` right?
-                let _ = robius_open::Uri::new(&self.url).open();
-            }
-        }
-    }
-}
-
-async fn fetch_image_blob(url: &str) -> Result<Vec<u8>, reqwest::Error> {
-    let client = reqwest::Client::new();
-    let response = client
-        .get(url)
-        // Trick the server into thinking we're a browser
-        .header(USER_AGENT, HeaderValue::from_static(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
-        ))
-        .send()
-        .await?;
-
-    let bytes = response.bytes().await?;
-    Ok(bytes.to_vec())
-}
-
-fn is_jpeg(bytes: &[u8]) -> bool {
-    bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8
-}
-
-fn is_png(bytes: &[u8]) -> bool {
-    bytes.len() >= 4 && bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47
 }


### PR DESCRIPTION
- Address warnings at `messages.rs`
- Move citations code out of `messages.rs`
- Fix citations preview click event.
- Refactored a little `ChatDelta`.