### PR TITLE
Moly kit streaming fixes

### DIFF
--- a/moly-kit/src/utils.rs
+++ b/moly-kit/src/utils.rs
@@ -4,6 +4,7 @@ pub mod asynchronous;
 pub(crate) mod events;
 pub(crate) mod portal_list;
 pub(crate) mod sse;
+pub(crate) mod ui_runner;
 
 #[cfg(feature = "json")]
 pub(crate) mod serde;

--- a/moly-kit/src/utils/ui_runner.rs
+++ b/moly-kit/src/utils/ui_runner.rs
@@ -1,0 +1,73 @@
+//! Extensions to [UiRunner] that make sense for moly kit.
+//!
+//! Async extensions could actually be part of [UiRunner] at makepad, but there is no
+//! `futures` crate there, and idk if the async channels implemented there would work
+//! propertly for this.
+
+use makepad_widgets::{Cx, DeferWithRedraw, Scope, UiRunner, Widget};
+
+pub trait AsyncDeferCallback<T, R>:
+    FnOnce(&mut T, &mut Cx, &mut Scope) -> R + Send + 'static
+where
+    R: Send + 'static,
+{
+}
+
+impl<T, R: Send + 'static, F: FnOnce(&mut T, &mut Cx, &mut Scope) -> R + Send + 'static>
+    AsyncDeferCallback<T, R> for F
+{
+}
+
+/// Async extension to [UiRunner], allowing to await until deferred closures are executed.
+#[allow(unused)]
+pub(crate) trait DeferAsync<T> {
+    /// Awaitable variant of [UiRunner::defer].
+    ///
+    /// This is actually similar to [UiRunner::block_on], but can be used inside
+    /// async contexts where is important to not block.
+    ///
+    /// The syncrhonous return value of the closure will be returned from the Future.
+    ///
+    /// The Future may give `None` if it couldn't receive a value back, because the
+    /// widget coudln't execute the closure. This can happen even without errors if
+    /// the widget is dropped before executing the pending closure.
+    async fn defer_async<R>(self, f: impl AsyncDeferCallback<T, R>) -> Option<R>
+    where
+        R: Send + 'static,
+        Self: Sized;
+}
+
+impl<T: 'static> DeferAsync<T> for UiRunner<T> {
+    async fn defer_async<R: Send + 'static>(self, f: impl AsyncDeferCallback<T, R>) -> Option<R> {
+        let (tx, rx) = futures::channel::oneshot::channel::<R>();
+        self.defer(move |me, cx, scope| {
+            let _ = tx.send(f(me, cx, scope));
+        });
+        rx.await.ok()
+    }
+}
+
+/// Async extension to [UiRunner], allowing to await until deferred closures with
+/// redraw are executed
+pub(crate) trait DeferWithRedrawAsync<T: 'static> {
+    /// Awaitable variant of [DeferWithRedraw::defer_with_redraw] based on [DeferAsync::defer_async].
+    ///
+    /// Return value behaves the same as [DeferAsync::defer_async].
+    async fn defer_with_redraw_async<R>(self, f: impl AsyncDeferCallback<T, R>) -> Option<R>
+    where
+        R: Send + 'static,
+        Self: Sized;
+}
+
+impl<W: Widget + 'static> DeferWithRedrawAsync<W> for UiRunner<W> {
+    async fn defer_with_redraw_async<R: Send + 'static>(
+        self,
+        f: impl AsyncDeferCallback<W, R>,
+    ) -> Option<R> {
+        let (tx, rx) = futures::channel::oneshot::channel::<R>();
+        self.defer_with_redraw(move |widget, cx, scope| {
+            let _ = tx.send(f(widget, cx, scope));
+        });
+        rx.await.ok()
+    }
+}

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -473,7 +473,6 @@ impl Chat {
     /// Called as soon as possible after streaming completes naturally or immediately when
     /// calling [Chat::abort].
     fn clean_streaming_artifacts(&mut self) {
-        log!("Cleaning streaming artifacts");
         self.abort_handle = None;
         self.expected_message = None;
         self.prompt_input_ref().write().set_send();

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -477,7 +477,8 @@ impl Chat {
         self.dispatch(cx, &mut tasks);
 
         let Some(ChatTask::UpdateMessage(_, message)) = tasks.pop() else {
-            panic!();
+            // Let's abort if the tasks were modified in an unexpected way.
+            return true;
         };
 
         self.expected_message = Some(message);

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -336,8 +336,9 @@ impl Chat {
         });
     }
 
-    fn handle_stop_task(&mut self, _cx: &mut Cx) {
+    fn handle_stop_task(&mut self, cx: &mut Cx) {
         self.abort();
+        self.redraw(cx);
     }
 
     /// Immediately remove resources/data related to the current streaming and signal

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -299,12 +299,16 @@ impl Chat {
                             }
                         }
 
-                        me.expected_message = Some(message.clone());
-
                         let index = messages.read().messages.len() - 1;
                         let is_at_bottom = messages.read().is_at_bottom();
 
-                        me.dispatch(cx, &mut ChatTask::UpdateMessage(index, message).into());
+                        let mut tasks = vec![ChatTask::UpdateMessage(index, message)];
+                        me.dispatch(cx, &mut tasks);
+
+                        let Some(ChatTask::UpdateMessage(_, message)) = tasks.pop() else {
+                            panic!();
+                        };
+                        me.expected_message = Some(message);
 
                         if is_at_bottom {
                             me.dispatch(cx, &mut ChatTask::ScrollToBottom.into());


### PR DESCRIPTION
# Changes

- Clean up stream artifacts propertly.
- Abort streaming on unexpected modifications.
- Ensure we wait for the previous message delta to be processed before going to the next one. 

# Manual testing

I recommend commenting the `self.messages_ref().write().scroll_to_bottom(cx);` line on `chat.rs` as the bug with auto scrolling will prevent you from trying  weird stuff like editing a previous message o deleting them while streaming.