### PR TITLE
fixed EOF while parsing a value error for MolyKit

### DIFF
--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -157,8 +157,21 @@ impl BotClient for OpenAIClient {
                 }
             };
 
-            let models: Models = match response.json().await {
-                Ok(models) => models,
+            let models: Models = match response.text().await {
+                Ok(text) => {
+                    if text.is_empty() {
+                        log!("Empty response from server");
+                        return Err(());
+                    }
+                    
+                    match serde_json::from_str(&text) {
+                        Ok(models) => models,
+                        Err(error) => {
+                            log!("Error parsing models response: {:?}, text: {}", error, text);
+                            return Err(());
+                        }
+                    }
+                },
                 Err(error) => {
                     log!("Error {:?}", error);
                     return Err(());


### PR DESCRIPTION
fixed EOF while parsing a value error in `moly-kit/src/clients/openai.rs`