### PR TITLE
Make moly pop up a notification box after a data stream interruption and retain the previous text in the UI. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ preferences.json
 /wasmedge
 /WasmEdge*
 .DS_Store
+CLAUDE.md

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -157,10 +157,23 @@ impl BotClient for OpenAIClient {
                 }
             };
 
-            let models: Models = match response.json().await {
-                Ok(models) => models,
+            let models: Models = match response.text().await {
+                Ok(text) => {
+                    if text.is_empty() {
+                        log!("Empty response from server");
+                        return Err(());
+                    }
+                    
+                    match serde_json::from_str(&text) {
+                        Ok(models) => models,
+                        Err(error) => {
+                            log!("Error parsing models response: {:?}, text: {}", error, text);
+                            return Err(());
+                        }
+                    }
+                },
                 Err(error) => {
-                    log!("Error {:?}", error);
+                    log!("Error fetching response text: {:?}", error);
                     return Err(());
                 }
             };

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -260,9 +260,12 @@ impl Chat {
             while let Some(delta) = message_stream.next().await {
                 let delta = match delta {
                     Ok(delta) => delta,
-                    Err(_) => MessageDelta {
-                        body: "An error occurred".to_string(),
-                        ..Default::default()
+                    Err(_) => {
+                        println!("Error receiving response: RecvError");
+                        MessageDelta {
+                            body: "\n\n[Connection interrupted. Please check your network...]".to_string(),
+                            ..Default::default()
+                        }
                     },
                 };
 
@@ -441,9 +444,10 @@ impl Chat {
         self.abort_handle = None;
         self.expected_message = None;
         self.prompt_input_ref().write().set_send();
+        // 保留所有消息，仅改变写入状态，不再按内容空白条件过滤
         self.messages_ref().write().messages.retain_mut(|m| {
             m.is_writing = false;
-            !m.body.is_empty()
+            true // 保留所有消息，即使内容为空
         });
     }
 

--- a/src/data/deep_inquire_client.rs
+++ b/src/data/deep_inquire_client.rs
@@ -211,6 +211,7 @@ impl DeepInquireClient {
                                         content: latest_content.clone(),
                                         articles: all_articles.clone(),
                                     };
+                                    // Use 0 as default ID when no valid completion was received
                                     let _ = tx.send(ChatResponse::DeepnInquireResponse(DeepInquireMessage::Completed(0, final_content)));
                                 }
                             },
@@ -266,6 +267,7 @@ struct DeltaContent {
     metadata: serde_json::Value,
     #[serde(default)]
     r#type: Option<String>,
+    #[serde(default)]
     id: usize,
 }
 

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -7,6 +7,7 @@ pub mod download_notification_popup;
 pub mod external_link;
 pub mod meta;
 pub mod modal;
+pub mod network_error_popup;
 pub mod popup_notification;
 pub mod resource_imports;
 pub mod styles;
@@ -24,6 +25,7 @@ pub fn live_design(cx: &mut Cx) {
     popup_notification::live_design(cx);
     external_link::live_design(cx);
     download_notification_popup::live_design(cx);
+    network_error_popup::live_design(cx);
     tooltip::live_design(cx);
     desktop_buttons::live_design(cx);
 }

--- a/src/shared/network_error_popup.rs
+++ b/src/shared/network_error_popup.rs
@@ -1,0 +1,189 @@
+use makepad_widgets::*;
+
+live_design! {
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+
+    use crate::shared::styles::*;
+    use crate::shared::resource_imports::*;
+    use crate::shared::widgets::MolyButton;
+
+    ERROR_ICON = dep("crate://self/resources/images/failure_icon.png")
+
+    NetworkErrorPopupDialog = <RoundedView> {
+        width: 350
+        height: Fit
+        margin: {top: 20, right: 20}
+        padding: {top: 20, right: 20 bottom: 20 left: 20}
+        spacing: 15
+
+        show_bg: true
+        draw_bg: {
+            color: #fff
+            instance border_radius: 4.0
+            fn pixel(self) -> vec4 {
+                let border_color = #d4;
+                let border_width = 1;
+                let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                let body = #fff
+
+                sdf.box(
+                    1.,
+                    1.,
+                    self.rect_size.x - 2.0,
+                    self.rect_size.y - 2.0,
+                    self.border_radius
+                )
+                sdf.fill_keep(body)
+
+                sdf.stroke(
+                    border_color,
+                    border_width
+                )
+                return sdf.result
+            }
+        }
+    }
+
+    NetworkErrorCloseButton = <MolyButton> {
+        width: Fit,
+        height: Fit,
+
+        margin: {top: -8}
+
+        draw_icon: {
+            svg_file: (ICON_CLOSE),
+            fn get_color(self) -> vec4 {
+                return #000;
+            }
+        }
+        icon_walk: {width: 10, height: 10}
+    }
+
+    NetworkErrorIcon = <View> {
+        width: Fit,
+        height: Fit,
+        margin: {top: -10, left: -10}
+        error_icon = <View> {
+            width: Fit,
+            height: Fit,
+            <Image> {
+                source: (ERROR_ICON),
+                width: 35,
+                height: 35,
+            }
+        }
+    }
+
+    NetworkErrorContent = <View> {
+        width: Fill,
+        height: Fit,
+        flow: Down,
+        spacing: 10
+
+        title = <Label> {
+            draw_text:{
+                text_style: <BOLD_FONT>{font_size: 9},
+                word: Wrap,
+                color: #000
+            }
+            text: "Network Connection Error"
+        }
+
+        message = <Label> {
+            width: Fill,
+            draw_text:{
+                text_style: <REGULAR_FONT>{font_size: 9},
+                word: Wrap,
+                color: #000
+            }
+            text: "Connection interrupted. Please check your network and try again."
+        }
+
+        actions = <View> {
+            width: Fit,
+            height: Fit,
+            retry_button = <MolyButton> {
+                text: "Try Again"
+            }
+        }
+    }
+
+    pub NetworkErrorPopup = {{NetworkErrorPopup}} {
+        width: Fit
+        height: Fit
+
+        <NetworkErrorPopupDialog> {
+            <NetworkErrorIcon> {}
+            <NetworkErrorContent> {}
+            close_button = <NetworkErrorCloseButton> {}
+        }
+    }
+}
+
+#[derive(Clone, Debug, DefaultNone)]
+pub enum NetworkErrorPopupAction {
+    None,
+    CloseButtonClicked,
+    RetryButtonClicked,
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct NetworkErrorPopup {
+    #[deref]
+    view: View,
+    #[layout]
+    layout: Layout,
+
+    #[rust]
+    custom_message: Option<String>,
+}
+
+impl Widget for NetworkErrorPopup {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let _ = self
+            .view
+            .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }));
+
+        DrawStep::done()
+    }
+}
+
+impl WidgetMatchEvent for NetworkErrorPopup {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        if self.button(id!(close_button)).clicked(actions) {
+            cx.action(NetworkErrorPopupAction::CloseButtonClicked);
+        }
+
+        if self.button(id!(retry_button)).clicked(actions) {
+            cx.action(NetworkErrorPopupAction::RetryButtonClicked);
+        }
+    }
+}
+
+impl NetworkErrorPopup {
+    pub fn set_message(&mut self, cx: &mut Cx, message: &str) {
+        self.custom_message = Some(message.to_string());
+        self.update_content(cx);
+    }
+
+    fn update_content(&mut self, cx: &mut Cx) {
+        if let Some(message) = &self.custom_message {
+            self.label(id!(message)).set_text(cx, message);
+        }
+    }
+}
+
+impl NetworkErrorPopupRef {
+    pub fn set_message(&mut self, cx: &mut Cx, message: &str) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_message(cx, message);
+        }
+    }
+}


### PR DESCRIPTION
The issue where the UI does not retain rendered content during data interruptions has been fixed. 

Additionally, I resolved a parsing error in the latest dev code where the `id` could not be parsed, so I changed it to support optional serialization.

<img width="987" alt="Screenshot 2025-03-26 at 17 45 54" src="https://github.com/user-attachments/assets/e0e28327-85fd-4a48-a359-78a8ff0704e4" />

<img width="1011" alt="Screenshot 2025-03-26 at 17 47 54" src="https://github.com/user-attachments/assets/504bc42e-c6f1-4361-8549-64eb367db402" />
