### PR TITLE
MolyKit error definitions and handling

### DIFF
--- a/moly-kit/src/clients/multi.rs
+++ b/moly-kit/src/clients/multi.rs
@@ -28,7 +28,7 @@ impl BotClient for MultiClient {
         &mut self,
         bot: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, Result<MessageDelta, ()>> {
+    ) -> MolyStream<'static, Result<MessageDelta, ClientError>> {
         let mut client = self
             .clients_with_bots
             .lock()
@@ -50,7 +50,7 @@ impl BotClient for MultiClient {
         Box::new(self.clone())
     }
 
-    fn bots(&self) -> MolyFuture<'static, Result<Vec<Bot>, ()>> {
+    fn bots(&self) -> MolyFuture<'static, Result<Vec<Bot>, ClientError>> {
         let clients_with_bots = self.clients_with_bots.clone();
 
         let future = async move {

--- a/moly-kit/src/clients/multi.rs
+++ b/moly-kit/src/clients/multi.rs
@@ -28,7 +28,7 @@ impl BotClient for MultiClient {
         &mut self,
         bot: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, Result<MessageDelta, ClientError>> {
+    ) -> MolyStream<'static, ClientResult<MessageDelta>> {
         let mut client = self
             .clients_with_bots
             .lock()
@@ -50,7 +50,7 @@ impl BotClient for MultiClient {
         Box::new(self.clone())
     }
 
-    fn bots(&self) -> MolyFuture<'static, Result<Vec<Bot>, ClientError>> {
+    fn bots(&self) -> MolyFuture<'static, ClientResult<Vec<Bot>>> {
         let clients_with_bots = self.clients_with_bots.clone();
 
         let future = async move {

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -140,7 +140,7 @@ impl OpenAIClient {
 }
 
 impl BotClient for OpenAIClient {
-    fn bots(&self) -> MolyFuture<'static, Result<Vec<Bot>, ClientError>> {
+    fn bots(&self) -> MolyFuture<'static, ClientResult<Vec<Bot>>> {
         let inner = self.0.clone();
 
         let future = async move {
@@ -157,7 +157,8 @@ impl BotClient for OpenAIClient {
                         ClientErrorKind::Network,
                         format!("An error ocurred sending a request to {url}."),
                         Some(error),
-                    ));
+                    )
+                    .into());
                 }
             };
 
@@ -166,7 +167,8 @@ impl BotClient for OpenAIClient {
                 return Err(ClientError::new(
                     ClientErrorKind::Remote,
                     format!("Got unexpected HTTP status code {code} from {url}."),
-                ));
+                )
+                .into());
             }
 
             let models: Models = match response.json().await {
@@ -176,7 +178,7 @@ impl BotClient for OpenAIClient {
                         ClientErrorKind::Format,
                         format!("Could not parse the response from {url} as JSON or its structure does not match the expected format."),
                         Some(error),
-                    ));
+                    ).into());
                 }
             };
 
@@ -209,7 +211,7 @@ impl BotClient for OpenAIClient {
         &mut self,
         bot: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, Result<MessageDelta, ClientError>> {
+    ) -> MolyStream<'static, ClientResult<MessageDelta>> {
         let moly_messages: Vec<OutcomingMessage> = messages
             .iter()
             .filter_map(|m| m.clone().try_into().ok())
@@ -241,7 +243,7 @@ impl BotClient for OpenAIClient {
                         ClientErrorKind::Network,
                         format!("An error ocurred sending a request to {url}."),
                         Some(error),
-                    ));
+                    ).into());
                     return;
                 }
             };
@@ -258,7 +260,7 @@ impl BotClient for OpenAIClient {
                             ClientErrorKind::Network,
                             format!("Something wrong happend while a chunk of bytes from {url}."),
                             Some(error),
-                        ));
+                        ).into());
                         return;
                     }
                 };
@@ -290,7 +292,7 @@ impl BotClient for OpenAIClient {
                                 ClientErrorKind::Format,
                                 format!("Could not parse the SSE message from {url} as JSON or its structure does not match the expected format."),
                                 Some(error),
-                            ));
+                            ).into());
                             return;
                         }
                     };

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -153,32 +153,32 @@ impl BotClient for OpenAIClient {
             let response = match request.send().await {
                 Ok(response) => response,
                 Err(error) => {
-                    return Err(ClientError::new_with_source(
+                    return ClientError::new_with_source(
                         ClientErrorKind::Network,
                         format!("An error ocurred sending a request to {url}."),
                         Some(error),
                     )
-                    .into());
+                    .into();
                 }
             };
 
             if !response.status().is_success() {
                 let code = response.status().as_u16();
-                return Err(ClientError::new(
+                return ClientError::new(
                     ClientErrorKind::Remote,
                     format!("Got unexpected HTTP status code {code} from {url}."),
                 )
-                .into());
+                .into();
             }
 
             let models: Models = match response.json().await {
                 Ok(models) => models,
                 Err(error) => {
-                    return Err(ClientError::new_with_source(
+                    return ClientError::new_with_source(
                         ClientErrorKind::Format,
                         format!("Could not parse the response from {url} as JSON or its structure does not match the expected format."),
                         Some(error),
-                    ).into());
+                    ).into();
                 }
             };
 
@@ -195,7 +195,7 @@ impl BotClient for OpenAIClient {
 
             bots.sort_by(|a, b| a.name.cmp(&b.name));
 
-            Ok(bots)
+            ClientResult::new_ok(bots)
         };
 
         moly_future(future)
@@ -239,11 +239,11 @@ impl BotClient for OpenAIClient {
             let response = match request.send().await {
                 Ok(response) => response,
                 Err(error) => {
-                    yield Err(ClientError::new_with_source(
+                    yield ClientError::new_with_source(
                         ClientErrorKind::Network,
                         format!("An error ocurred sending a request to {url}."),
                         Some(error),
-                    ).into());
+                    ).into();
                     return;
                 }
             };
@@ -256,11 +256,11 @@ impl BotClient for OpenAIClient {
                 let chunk = match chunk {
                     Ok(chunk) => chunk,
                     Err(error) => {
-                        yield Err(ClientError::new_with_source(
+                        yield ClientError::new_with_source(
                             ClientErrorKind::Network,
                             format!("Something wrong happend while a chunk of bytes from {url}."),
                             Some(error),
-                        ).into());
+                        ).into();
                         return;
                     }
                 };
@@ -288,11 +288,11 @@ impl BotClient for OpenAIClient {
                     let completion: Completion = match serde_json::from_str(m) {
                         Ok(c) => c,
                         Err(error) => {
-                            yield Err(ClientError::new_with_source(
+                            yield ClientError::new_with_source(
                                 ClientErrorKind::Format,
                                 format!("Could not parse the SSE message from {url} as JSON or its structure does not match the expected format."),
                                 Some(error),
-                            ).into());
+                            ).into();
                             return;
                         }
                     };
@@ -305,7 +305,7 @@ impl BotClient for OpenAIClient {
 
                     let citations = completion.citations;
 
-                    yield Ok(MessageDelta {
+                    yield ClientResult::new_ok(MessageDelta {
                         body,
                         citations,
                     });

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -1,5 +1,4 @@
 use async_stream::stream;
-use makepad_widgets::log;
 use reqwest::header::{HeaderMap, HeaderName};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -141,40 +140,43 @@ impl OpenAIClient {
 }
 
 impl BotClient for OpenAIClient {
-    fn bots(&self) -> MolyFuture<'static, Result<Vec<Bot>, ()>> {
+    fn bots(&self) -> MolyFuture<'static, Result<Vec<Bot>, ClientError>> {
         let inner = self.0.clone();
 
         let future = async move {
+            let url = format!("{}/v1/models", inner.lock().unwrap().url);
+
             let request = reqwest::Client::new()
-                .get(format!("{}/v1/models", inner.lock().unwrap().url))
+                .get(&url)
                 .headers(inner.lock().unwrap().headers.clone());
 
             let response = match request.send().await {
                 Ok(response) => response,
                 Err(error) => {
-                    log!("Error {:?}", error);
-                    return Err(());
+                    return Err(ClientError::new_with_source(
+                        ClientErrorKind::Network,
+                        format!("An error ocurred sending a request to {url}."),
+                        Some(error),
+                    ));
                 }
             };
 
-            let models: Models = match response.text().await {
-                Ok(text) => {
-                    if text.is_empty() {
-                        log!("Empty response from server");
-                        return Err(());
-                    }
-                    
-                    match serde_json::from_str(&text) {
-                        Ok(models) => models,
-                        Err(error) => {
-                            log!("Error parsing models response: {:?}, text: {}", error, text);
-                            return Err(());
-                        }
-                    }
-                },
+            if !response.status().is_success() {
+                let code = response.status().as_u16();
+                return Err(ClientError::new(
+                    ClientErrorKind::Remote,
+                    format!("Got unexpected HTTP status code {code} from {url}."),
+                ));
+            }
+
+            let models: Models = match response.json().await {
+                Ok(models) => models,
                 Err(error) => {
-                    log!("Error {:?}", error);
-                    return Err(());
+                    return Err(ClientError::new_with_source(
+                        ClientErrorKind::Format,
+                        format!("Could not parse the response from {url} as JSON or its structure does not match the expected format."),
+                        Some(error),
+                    ));
                 }
             };
 
@@ -207,7 +209,7 @@ impl BotClient for OpenAIClient {
         &mut self,
         bot: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, Result<MessageDelta, ()>> {
+    ) -> MolyStream<'static, Result<MessageDelta, ClientError>> {
         let moly_messages: Vec<OutcomingMessage> = messages
             .iter()
             .filter_map(|m| m.clone().try_into().ok())
@@ -218,8 +220,10 @@ impl BotClient for OpenAIClient {
             (inner.url.clone(), inner.headers.clone())
         };
 
+        let url = format!("{}/v1/chat/completions", url);
+
         let request = reqwest::Client::new()
-            .post(format!("{}/v1/chat/completions", url))
+            .post(&url)
             .headers(headers)
             .json(&serde_json::json!({
                 "model": bot.as_str(),
@@ -233,8 +237,11 @@ impl BotClient for OpenAIClient {
             let response = match request.send().await {
                 Ok(response) => response,
                 Err(error) => {
-                    log!("Error {:?}", error);
-                    yield Err(());
+                    yield Err(ClientError::new_with_source(
+                        ClientErrorKind::Network,
+                        format!("An error ocurred sending a request to {url}."),
+                        Some(error),
+                    ));
                     return;
                 }
             };
@@ -247,8 +254,11 @@ impl BotClient for OpenAIClient {
                 let chunk = match chunk {
                     Ok(chunk) => chunk,
                     Err(error) => {
-                        log!("Error {:?}", error);
-                        yield Err(());
+                        yield Err(ClientError::new_with_source(
+                            ClientErrorKind::Network,
+                            format!("Something wrong happend while a chunk of bytes from {url}."),
+                            Some(error),
+                        ));
                         return;
                     }
                 };
@@ -268,6 +278,7 @@ impl BotClient for OpenAIClient {
                     completed_messages
                     .split(event_terminator_str)
                     .filter(|m| !m.starts_with(":"))
+                    // TODO: Return a format error instead of unwraping.
                     .map(|m| m.trim_start().split("data:").nth(1).unwrap())
                     .filter(|m| m.trim() != "[DONE]");
 
@@ -275,8 +286,11 @@ impl BotClient for OpenAIClient {
                     let completion: Completion = match serde_json::from_str(m) {
                         Ok(c) => c,
                         Err(error) => {
-                            log!("Error: {:?}", error);
-                            yield Err(());
+                            yield Err(ClientError::new_with_source(
+                                ClientErrorKind::Format,
+                                format!("Could not parse the SSE message from {url} as JSON or its structure does not match the expected format."),
+                                Some(error),
+                            ));
                             return;
                         }
                     };

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -55,15 +55,15 @@ impl From<&str> for BotId {
     }
 }
 
-impl ToString for BotId {
-    fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-}
-
 impl BotId {
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl fmt::Display for BotId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
@@ -98,18 +98,21 @@ pub struct MessageDelta {
 pub enum ClientErrorKind {
     /// The network connection could not be established properly or was lost.
     Network,
+
     /// The connection could be established, but the remote server/peer gave us
     /// an error.
     ///
     /// Example: On a centralized HTTP server, this would happen when it returns
     /// an HTTP error code.
     Remote,
+
     /// The remote server/peer returned a successful response, but we can't parse
     /// its content.
     ///
     /// Example: When working with JSON APIs, this can happen when the schema of
     /// the JSON response is not what we expected or is not JSON at all.
     Format,
+
     /// A kind of error that is not contemplated by MolyKit at the client layer.
     Unknown,
 }

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -68,19 +68,6 @@ impl fmt::Display for BotId {
     }
 }
 
-/// The level of a message similar to log levels.
-///
-/// Controls when and how the message should be displayed.
-#[derive(Copy, Clone, PartialEq, Debug, Default)]
-pub enum MessageLevel {
-    /// A message displayed without any special meaning.
-    #[default]
-    Normal,
-
-    /// A message displayed as an error.
-    Error,
-}
-
 /// A message that is part of a conversation.
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct Message {
@@ -99,9 +86,6 @@ pub struct Message {
 
     /// Citations for the message.
     pub citations: Vec<String>,
-
-    /// The level of the message. See [MessageLevel] for more information.
-    pub level: MessageLevel,
 }
 
 /// A delta response for an existing [Message].
@@ -137,15 +121,14 @@ pub enum ClientErrorKind {
     Unknown,
 }
 
-impl fmt::Display for ClientErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let kind_str = match self {
-            ClientErrorKind::Network => "NetworkError",
-            ClientErrorKind::Remote => "RemoteError",
-            ClientErrorKind::Format => "FormatError",
-            ClientErrorKind::Unknown => "UnknownError",
-        };
-        write!(f, "{}", kind_str)
+impl ClientErrorKind {
+    pub fn to_human_readable(&self) -> &str {
+        match self {
+            ClientErrorKind::Network => "Network error",
+            ClientErrorKind::Remote => "Remote error",
+            ClientErrorKind::Format => "Format error",
+            ClientErrorKind::Unknown => "Unknown error",
+        }
     }
 }
 
@@ -159,7 +142,7 @@ pub struct ClientError {
 
 impl fmt::Display for ClientError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.kind, self.message)
+        write!(f, "{}: {}", self.kind.to_human_readable(), self.message)
     }
 }
 

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -19,7 +19,7 @@ pub enum Picture {
 }
 
 /// Indentify the entities that are recognized by this crate, mainly in a chat.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
 pub enum EntityId {
     /// Represents the user operating this app.
     User,
@@ -35,6 +35,7 @@ pub enum EntityId {
     /// (like inline errors).
     ///
     /// It's not supposed to be sent as part of a conversation to bots.
+    #[default]
     App,
 }
 
@@ -67,21 +68,40 @@ impl fmt::Display for BotId {
     }
 }
 
+/// The level of a message similar to log levels.
+///
+/// Controls when and how the message should be displayed.
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub enum MessageLevel {
+    /// A message displayed without any special meaning.
+    #[default]
+    Normal,
+
+    /// A message displayed as an error.
+    Error,
+}
+
 /// A message that is part of a conversation.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct Message {
     /// The id of who sent this message.
     pub from: EntityId,
+
     /// Content of the message.
     pub body: String,
+
     /// If this message is still being written.
     ///
     /// This means the message is still going to be modified.
     ///
     /// If `false`, it means the message will not change anymore.
     pub is_writing: bool,
+
     /// Citations for the message.
     pub citations: Vec<String>,
+
+    /// The level of the message. See [MessageLevel] for more information.
+    pub level: MessageLevel,
 }
 
 /// A delta response for an existing [Message].

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -149,9 +149,15 @@ impl Error for ClientError {
     }
 }
 
-impl<T> From<ClientError> for (Vec<ClientError>, Option<T>) {
+impl From<ClientError> for Vec<ClientError> {
     fn from(error: ClientError) -> Self {
-        (vec![error], None)
+        vec![error]
+    }
+}
+
+impl<T> From<ClientError> for ClientResult<T> {
+    fn from(error: ClientError) -> Self {
+        ClientResult::new_err(vec![error])
     }
 }
 
@@ -193,9 +199,103 @@ impl ClientError {
 
 /// The outcome of a client operation.
 ///
-/// The error variant may contain multiple errors and may still contain a successful
-/// result if the operation was partially successful.
-pub type ClientResult<T> = Result<T, (Vec<ClientError>, Option<T>)>;
+/// Different from the standard Result, this one may contain more than one error.
+/// And at the same time, even if an error ocurrs, there may be a value to rescue.
+///
+/// It would be mistake if this contains no value and no errors at the same time.
+/// This is taken care on creation time, and it can't be modified afterwards.
+pub struct ClientResult<T> {
+    errors: Vec<ClientError>,
+    value: Option<T>,
+}
+
+impl<T> ClientResult<T> {
+    /// Creates a result containing a successful value and no errors.
+    pub fn new_ok(value: T) -> Self {
+        ClientResult {
+            errors: Vec::new(),
+            value: Some(value),
+        }
+    }
+
+    /// Creates a result containing errors and no value to rescue.
+    ///
+    /// The errors list should be non empty. If it's empty a default error will
+    /// be added to avoid the invariant of having no value and no errors at the
+    /// same time.
+    pub fn new_err(errors: Vec<ClientError>) -> Self {
+        let errors = if errors.is_empty() {
+            vec![ClientError::new(
+                ClientErrorKind::Unknown,
+                "An error ocurred, but no details were provided.".into(),
+            )]
+        } else {
+            errors
+        };
+
+        ClientResult {
+            errors,
+            value: None,
+        }
+    }
+
+    /// Creates a result containing errors and a value to rescue.
+    ///
+    /// This method should only be used when there are both errors and a value.
+    /// - If there are no errors, use [ClientResult::new_ok] instead.
+    /// - Similar to [ClientResult::new_err], if the errors list is empty, a default
+    /// error will be added.
+    pub fn new_ok_and_err(value: T, errors: Vec<ClientError>) -> Self {
+        let errors = if errors.is_empty() {
+            vec![ClientError::new(
+                ClientErrorKind::Unknown,
+                "An error ocurred, but no details were provided.".into(),
+            )]
+        } else {
+            errors
+        };
+
+        ClientResult {
+            errors,
+            value: Some(value),
+        }
+    }
+
+    /// Returns the successful value if there is one.
+    pub fn value(&self) -> Option<&T> {
+        self.value.as_ref()
+    }
+
+    /// Returns the errors list.
+    pub fn errors(&self) -> &[ClientError] {
+        &self.errors
+    }
+
+    /// Returns true if there is a successful value.
+    pub fn has_value(&self) -> bool {
+        self.value.is_some()
+    }
+
+    /// Returns true if there are errors.
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Consume the result and return the successful value if there is one.
+    pub fn into_value(self) -> Option<T> {
+        self.value
+    }
+
+    /// Consume the result and return the errors list.
+    pub fn into_errors(self) -> Vec<ClientError> {
+        self.errors
+    }
+
+    /// Consume the result and return the successful value and the errors list.
+    pub fn into_value_and_errors(self) -> (Option<T>, Vec<ClientError>) {
+        (self.value, self.errors)
+    }
+}
 
 /// A standard interface to fetch bots information and send messages to them.
 ///
@@ -238,19 +338,28 @@ pub trait BotClient: Send {
         let future = async move {
             let mut body = String::new();
             let mut citations = Vec::new();
+            let mut errors = Vec::new();
 
             let mut stream = stream;
-            while let Some(delta) = stream.next().await {
-                match delta {
-                    Ok(delta) => {
-                        body.push_str(&delta.body);
-                        citations.extend(delta.citations);
-                    }
-                    Err(error) => return Err(error),
+            while let Some(result) = stream.next().await {
+                let (v, e) = result.into_value_and_errors();
+
+                if let Some(delta) = v {
+                    body.push_str(&delta.body);
+                    citations.extend(delta.citations);
+                }
+
+                if !e.is_empty() {
+                    errors.extend(e);
+                    break;
                 }
             }
 
-            Ok(MessageDelta { body, citations })
+            if errors.is_empty() {
+                ClientResult::new_ok(MessageDelta { body, citations })
+            } else {
+                ClientResult::new_ok_and_err(MessageDelta { body, citations }, errors)
+            }
         };
 
         moly_future(future)
@@ -303,17 +412,17 @@ impl BotRepo {
     /// It errors with whatever the underlying client errors with.
     pub fn load(&mut self) -> MolyFuture<ClientResult<()>> {
         let future = async move {
-            let new_bots = self.client().bots().await;
+            let result = self.client().bots().await;
+            let (new_bots, errors) = result.into_value_and_errors();
 
-            match new_bots {
-                Ok(bots) => {
-                    self.0.lock().unwrap().bots = bots;
-                    Ok(())
-                }
-                Err((errors, bots)) => {
-                    self.0.lock().unwrap().bots = bots.unwrap_or_default();
-                    Err((errors, None))
-                }
+            if let Some(new_bots) = new_bots {
+                self.0.lock().unwrap().bots = new_bots;
+            }
+
+            if errors.is_empty() {
+                ClientResult::new_ok(())
+            } else {
+                ClientResult::new_err(errors)
             }
         };
 

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -295,6 +295,15 @@ impl<T> ClientResult<T> {
     pub fn into_value_and_errors(self) -> (Option<T>, Vec<ClientError>) {
         (self.value, self.errors)
     }
+
+    /// Consume the result to convert it into a standard Result.
+    pub fn into_result(self) -> Result<T, Vec<ClientError>> {
+        if self.errors.is_empty() {
+            Ok(self.value.expect("ClientResult has no value nor errors"))
+        } else {
+            Err(self.errors)
+        }
+    }
 }
 
 /// A standard interface to fetch bots information and send messages to them.

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -203,8 +203,7 @@ impl Chat {
                     Message {
                         from: EntityId::User,
                         body: text.clone(),
-                        is_writing: false,
-                        citations: vec![],
+                        ..Default::default()
                     },
                 ));
             }
@@ -235,9 +234,8 @@ impl Chat {
 
             messages.messages.push(Message {
                 from: EntityId::Bot(bot_id.clone()),
-                body: String::new(),
                 is_writing: true,
-                citations: vec![],
+                ..Default::default()
             });
 
             messages
@@ -494,8 +492,8 @@ impl Chat {
                             Message {
                                 from: EntityId::App,
                                 body: e.to_string(),
-                                is_writing: false,
-                                citations: vec![],
+                                level: MessageLevel::Error,
+                                ..Default::default()
                             },
                         )
                     })

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -492,7 +492,6 @@ impl Chat {
                             Message {
                                 from: EntityId::App,
                                 body: e.to_string(),
-                                level: MessageLevel::Error,
                                 ..Default::default()
                             },
                         )

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -257,13 +257,14 @@ impl Chat {
             let mut client = repo.client();
 
             let mut message_stream = client.send_stream(&bot_id, &context);
-            while let Some(delta) = message_stream.next().await {
-                let delta = match delta {
-                    Ok(delta) => delta,
-                    Err(_) => MessageDelta {
+            while let Some(result) = message_stream.next().await {
+                let delta = if let Some(delta) = result.into_value() {
+                    delta
+                } else {
+                    MessageDelta {
                         body: "An error occurred".to_string(),
                         ..Default::default()
-                    },
+                    }
                 };
 
                 // In theory, with the synchroneous defer, if stream messages come

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -258,15 +258,6 @@ impl Chat {
 
             let mut message_stream = client.send_stream(&bot_id, &context);
             while let Some(result) = message_stream.next().await {
-                let delta = if let Some(delta) = result.into_value() {
-                    delta
-                } else {
-                    MessageDelta {
-                        body: "An error occurred".to_string(),
-                        ..Default::default()
-                    }
-                };
-
                 // In theory, with the synchroneous defer, if stream messages come
                 // faster than deferred closures are executed, and one closure causes
                 // an abort, the other already deferred closures will still be executed
@@ -277,7 +268,7 @@ impl Chat {
                 // the next delta. And also allows to stop naturally from here as well
                 // thanks to its ability to send a value back.
                 let should_break = ui
-                    .defer_with_redraw_async(move |me, cx, _| me.handle_message_delta(cx, delta))
+                    .defer_with_redraw_async(move |me, cx, _| me.handle_message_delta(cx, result))
                     .await;
 
                 if should_break.unwrap_or(true) {
@@ -448,47 +439,77 @@ impl Chat {
         });
     }
 
-    fn handle_message_delta(&mut self, cx: &mut Cx, delta: MessageDelta) -> bool {
+    fn handle_message_delta(&mut self, cx: &mut Cx, result: ClientResult<MessageDelta>) -> bool {
         let messages = self.messages_ref();
 
-        // Let's stop if we don't have where to put the delta.
-        let Some(mut message) = messages.read().messages.last().cloned() else {
-            return true;
-        };
+        // For simplicity, lets handle this as an standard Result, ignoring delta
+        // if there are errors.
+        match result.into_result() {
+            Ok(delta) => {
+                // Let's abort if we don't have where to put the delta.
+                let Some(mut message) = messages.read().messages.last().cloned() else {
+                    return true;
+                };
 
-        // Let's abort if we see we are putting delta in the wrong message.
-        if let Some(expected_message) = self.expected_message.as_ref() {
-            if message != *expected_message {
-                return true;
+                // Let's abort if we see we are putting delta in the wrong message.
+                if let Some(expected_message) = self.expected_message.as_ref() {
+                    if message != *expected_message {
+                        return true;
+                    }
+                }
+
+                message.body.push_str(&delta.body);
+                // Note: Maybe this is a good case for a sorted set, like `BTreeSet`.
+                for citation in delta.citations {
+                    if !message.citations.contains(&citation) {
+                        message.citations.push(citation);
+                    }
+                }
+
+                let index = messages.read().messages.len() - 1;
+                let mut tasks = vec![ChatTask::UpdateMessage(index, message)];
+
+                if messages.read().is_at_bottom() {
+                    tasks.push(ChatTask::ScrollToBottom);
+                }
+
+                self.dispatch(cx, &mut tasks);
+
+                let Some(ChatTask::UpdateMessage(_, message)) = tasks.into_iter().next() else {
+                    // Let's abort if the tasks were modified in an unexpected way.
+                    return true;
+                };
+
+                self.expected_message = Some(message);
+
+                false
+            }
+            Err(errors) => {
+                let mut tasks = errors
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, e)| {
+                        ChatTask::InsertMessage(
+                            messages.read().messages.len() + i,
+                            Message {
+                                from: EntityId::App,
+                                body: e.to_string(),
+                                is_writing: false,
+                                citations: vec![],
+                            },
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                if messages.read().is_at_bottom() {
+                    tasks.push(ChatTask::ScrollToBottom);
+                }
+
+                self.dispatch(cx, &mut tasks);
+
+                true
             }
         }
-
-        message.body.push_str(&delta.body);
-        // Note: Maybe this is a good case for a sorted set, like `BTreeSet`.
-        for citation in delta.citations {
-            if !message.citations.contains(&citation) {
-                message.citations.push(citation);
-            }
-        }
-
-        let index = messages.read().messages.len() - 1;
-        let is_at_bottom = messages.read().is_at_bottom();
-
-        let mut tasks = vec![ChatTask::UpdateMessage(index, message)];
-        self.dispatch(cx, &mut tasks);
-
-        let Some(ChatTask::UpdateMessage(_, message)) = tasks.pop() else {
-            // Let's abort if the tasks were modified in an unexpected way.
-            return true;
-        };
-
-        self.expected_message = Some(message);
-
-        if is_at_bottom {
-            self.dispatch(cx, &mut ChatTask::ScrollToBottom.into());
-        }
-
-        false
     }
 }
 

--- a/moly-kit/src/widgets/citations.rs
+++ b/moly-kit/src/widgets/citations.rs
@@ -108,6 +108,12 @@ impl Widget for Citations {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        // Without this, margins and paddings would be considered even if not visible
+        // because of the turtle.
+        if !self.visible {
+            return DrawStep::done();
+        }
+
         // TODO: Fix this, currently redrawing on every event
         // And at the same time, the citations are not being redrawn unless there's a user-triggered event like mouse move or window resize.
         cx.begin_turtle(walk, self.layout);

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -2,8 +2,11 @@ use std::cell::{Ref, RefMut};
 
 use crate::{
     protocol::*,
-    utils::{asynchronous::spawn, events::EventExt, portal_list::ItemsRangeIter},
-    widgets::{avatar::AvatarWidgetRefExt, message_loading::MessageLoadingWidgetRefExt, message_thinking_block::MessageThinkingBlockWidgetRefExt},
+    utils::{events::EventExt, portal_list::ItemsRangeIter},
+    widgets::{
+        avatar::AvatarWidgetRefExt, message_loading::MessageLoadingWidgetRefExt,
+        message_thinking_block::MessageThinkingBlockWidgetRefExt,
+    },
 };
 use makepad_widgets::*;
 
@@ -48,7 +51,7 @@ live_design! {
         }
     }
 
-    ActionButton =  <Button> {
+    ActionButton = <Button> {
         width: 14
         height: 14
         icon_walk: {width: 14, height: 14},
@@ -104,10 +107,13 @@ live_design! {
     ChatLine = <RoundedView> {
         flow: Down,
         height: Fit,
-        sender = <Sender> {}
-        bubble = <Bubble> {}
+        message_section = <RoundedView> {
+            flow: Down,
+            height: Fit,
+            sender = <Sender> {}
+            bubble = <Bubble> {}
+        }
         actions_section = <View> {
-            width: Fill,
             margin: {top: 8, bottom: 8},
             height: 16,
             actions = <Actions> { visible: false }
@@ -117,21 +123,23 @@ live_design! {
 
     UserLine = <ChatLine> {
         height: Fit,
-        sender = { visible: false }
-        bubble = <Bubble> {
-            margin: {left: 100}
-            draw_bg: {color: #15859A}
-            text = <View> {
-                height: Fit
-                label = <Label> {
-                    width: Fill,
-                    draw_text: {
-                        // text_style: <REGULAR_FONT>{height_factor: (1.3*1.3), font_size: 10},
-                        color: #fff
+        message_section = {
+            sender = { visible: false }
+            bubble = <Bubble> {
+                margin: {left: 100}
+                draw_bg: {color: #15859A}
+                text = <View> {
+                    height: Fit
+                    label = <Label> {
+                        width: Fill,
+                        draw_text: {
+                            // text_style: <REGULAR_FONT>{height_factor: (1.3*1.3), font_size: 10},
+                            color: #fff
+                        }
                     }
                 }
+                editor = <Editor> { visible: false }
             }
-            editor = <Editor> { visible: false }
         }
         actions_section = {
             margin: {left: 100}
@@ -141,18 +149,20 @@ live_design! {
     BotLine = <ChatLine> {
         flow: Down,
         height: Fit,
-        bubble = <Bubble> {
-            flow: Down,
-            padding: 0,
-            margin: {left: 32}
-            text = <View> {
-                flow: Down
-                height: Fit,
-                thinking_block = <MessageThinkingBlock> {margin: {bottom: 10}}
-                markdown = <MessageMarkdown> {}
+        message_section = {
+            bubble = <Bubble> {
+                flow: Down,
+                padding: 0,
+                margin: {left: 32}
+                text = <View> {
+                    flow: Down
+                    height: Fit,
+                    thinking_block = <MessageThinkingBlock> {margin: {bottom: 10}}
+                    markdown = <MessageMarkdown> {}
+                }
+                editor = <Editor> { visible: false }
+                citations = <Citations> { visible: false }
             }
-            editor = <Editor> { visible: false }
-            citations = <Citations> { visible: false }
         }
         actions_section = {
             margin: {left: 32}
@@ -160,10 +170,12 @@ live_design! {
     }
 
     LoadingLine = <BotLine> {
-        bubble = {
-            text = <View> {
-                height: Fit,
-                loading = <MessageLoading> {}
+        message_section = {
+            bubble = {
+                text = <View> {
+                    height: Fit,
+                    loading = <MessageLoading> {}
+                }
             }
         }
     }
@@ -172,7 +184,31 @@ live_design! {
     // Idea: With the current design, this can be something centered and fit
     // up to the fill size. If we drop the current design and simplify it, we could
     // just use the bot's design for all messages.
-    AppLine = <BotLine> {}
+    AppLine = <BotLine> {
+        message_section = {
+            padding: 12,
+            draw_bg: {color: #00f3}
+            sender = {
+                avatar = {
+                    grapheme = {draw_bg: {color: #00f3}}
+                }
+                name = {text: "Application"}
+            }
+        }
+    }
+
+    ErrorLine = <AppLine> {
+        message_section = {
+            padding: 12,
+            draw_bg: {color: #f003}
+
+            sender = {
+                avatar = {
+                    grapheme = {draw_bg: {color: #f003}}
+                }
+            }
+        }
+    }
 
     pub Messages = {{Messages}} {
         flow: Overlay,
@@ -184,6 +220,7 @@ live_design! {
             BotLine = <BotLine> {}
             LoadingLine = <LoadingLine> {}
             AppLine = <AppLine> {}
+            ErrorLine = <ErrorLine> {}
 
             // Acts as marker for:
             // - Knowing if the end of the list has been reached.
@@ -342,49 +379,37 @@ impl Messages {
                     // TODO: Can or should system messages be rendered?
                 }
                 EntityId::App => {
-                    // TODO: Display app messages. They may be errors.
                     if message.body == "EOC" {
                         let item = list.item(cx, index, live_id!(EndOfChat));
                         item.draw_all(cx, &mut Scope::empty());
                         self.is_list_end_drawn = true;
-                    } else {
-                        let item = list.item(cx, index, live_id!(AppLine));
-                        item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
-                            Some(Picture::Grapheme("A".into()));
-                        item.label(id!(name)).set_text(cx, "Application");
-                        item.label(id!(text.markdown)).set_text(cx, &message.body);
-
-                        if let MessageLevel::Error = message.level {
-                            item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
-                                Some(Picture::Grapheme("E".into()));
-
-                            item.avatar(id!(avatar)).view(id!(grapheme)).apply_over(
-                                cx,
-                                live! {
-                                    draw_bg: {
-                                        color: #f003
-                                    }
-                                },
-                            );
-
-                            item.label(id!(name)).set_text(cx, "Error");
-
-                            item.apply_over(
-                                cx,
-                                live! {
-                                    padding: {left: 12, top: 12},
-                                    margin: {bottom: 8},
-                                    draw_bg: {
-                                        radius: 8.0,
-                                        color: #f003
-                                    }
-                                },
-                            );
-                        }
-
-                        self.apply_actions_and_editor_visibility(cx, &item, index);
-                        item.draw_all(cx, &mut Scope::empty());
+                        continue;
                     }
+
+                    if let Some((left, right)) = message.body.split_once(':') {
+                        if let Some("error") = left
+                            .split_whitespace()
+                            .last()
+                            .map(|s| s.to_lowercase())
+                            .as_deref()
+                        {
+                            let item = list.item(cx, index, live_id!(ErrorLine));
+                            item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                                Some(Picture::Grapheme("X".into()));
+                            item.label(id!(name)).set_text(cx, left);
+                            item.label(id!(text.markdown)).set_text(cx, right);
+                            self.apply_actions_and_editor_visibility(cx, &item, index);
+                            item.draw_all(cx, &mut Scope::empty());
+                            continue;
+                        }
+                    }
+
+                    let item = list.item(cx, index, live_id!(AppLine));
+                    item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                        Some(Picture::Grapheme("A".into()));
+                    item.label(id!(text.markdown)).set_text(cx, &message.body);
+                    self.apply_actions_and_editor_visibility(cx, &item, index);
+                    item.draw_all(cx, &mut Scope::empty());
                 }
                 EntityId::User => {
                     let item = list.item(cx, index, live_id!(UserLine));
@@ -420,9 +445,11 @@ impl Messages {
                         // from the list, you should remove the unicode character.
                         // TODO: Remove this workaround once the markdown widget is fixed.
 
-                        let (thinking_block, message_body) = extract_and_remove_think_tag(&message.body);
+                        let (thinking_block, message_body) =
+                            extract_and_remove_think_tag(&message.body);
 
-                        item.message_thinking_block(id!(text.thinking_block)).set_thinking_text(thinking_block);
+                        item.message_thinking_block(id!(text.thinking_block))
+                            .set_thinking_text(thinking_block);
 
                         if let Some(body) = message_body {
                             item.label(id!(text.markdown))

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -195,11 +195,13 @@ live_design! {
                 name = {text: "Application"}
             }
         }
+        actions_section = {
+            margin: {left: 2}
+        }
     }
 
     ErrorLine = <AppLine> {
         message_section = {
-            padding: 12,
             draw_bg: {color: #f003}
 
             sender = {

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -354,6 +354,7 @@ impl Messages {
                             Some(Picture::Grapheme("A".into()));
                         item.label(id!(name)).set_text(cx, "Application");
                         item.label(id!(text.markdown)).set_text(cx, &message.body);
+                        self.apply_actions_and_editor_visibility(cx, &item, index);
                         item.draw_all(cx, &mut Scope::empty());
                     }
                 }

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -101,7 +101,7 @@ live_design! {
         }
     }
 
-    ChatLine = <View> {
+    ChatLine = <RoundedView> {
         flow: Down,
         height: Fit,
         sender = <Sender> {}
@@ -142,8 +142,8 @@ live_design! {
         flow: Down,
         height: Fit,
         bubble = <Bubble> {
-            flow: Down, spacing: 10
-            padding: {left: 0, top: 0, bottom: 0},
+            flow: Down,
+            padding: 0,
             margin: {left: 32}
             text = <View> {
                 flow: Down
@@ -318,8 +318,7 @@ impl Messages {
             from: EntityId::App,
             // End-of-chat
             body: "EOC".into(),
-            is_writing: false,
-            citations: vec![],
+            ..Default::default()
         });
 
         let mut list = list.borrow_mut().unwrap();
@@ -354,6 +353,35 @@ impl Messages {
                             Some(Picture::Grapheme("A".into()));
                         item.label(id!(name)).set_text(cx, "Application");
                         item.label(id!(text.markdown)).set_text(cx, &message.body);
+
+                        if let MessageLevel::Error = message.level {
+                            item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                                Some(Picture::Grapheme("E".into()));
+
+                            item.avatar(id!(avatar)).view(id!(grapheme)).apply_over(
+                                cx,
+                                live! {
+                                    draw_bg: {
+                                        color: #f003
+                                    }
+                                },
+                            );
+
+                            item.label(id!(name)).set_text(cx, "Error");
+
+                            item.apply_over(
+                                cx,
+                                live! {
+                                    padding: {left: 12, top: 12},
+                                    margin: {bottom: 8},
+                                    draw_bg: {
+                                        radius: 8.0,
+                                        color: #f003
+                                    }
+                                },
+                            );
+                        }
+
                         self.apply_actions_and_editor_visibility(cx, &item, index);
                         item.draw_all(cx, &mut Scope::empty());
                     }

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -168,6 +168,12 @@ live_design! {
         }
     }
 
+    // Note: For now, let's use bot's apparence for app messages.
+    // Idea: With the current design, this can be something centered and fit
+    // up to the fill size. If we drop the current design and simplify it, we could
+    // just use the bot's design for all messages.
+    AppLine = <BotLine> {}
+
     pub Messages = {{Messages}} {
         flow: Overlay,
         list = <PortalList> {
@@ -177,6 +183,7 @@ live_design! {
             UserLine = <UserLine> {}
             BotLine = <BotLine> {}
             LoadingLine = <LoadingLine> {}
+            AppLine = <AppLine> {}
 
             // Acts as marker for:
             // - Knowing if the end of the list has been reached.
@@ -342,7 +349,12 @@ impl Messages {
                         item.draw_all(cx, &mut Scope::empty());
                         self.is_list_end_drawn = true;
                     } else {
-                        todo!();
+                        let item = list.item(cx, index, live_id!(AppLine));
+                        item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                            Some(Picture::Grapheme("A".into()));
+                        item.label(id!(name)).set_text(cx, "Application");
+                        item.label(id!(text.markdown)).set_text(cx, &message.body);
+                        item.draw_all(cx, &mut Scope::empty());
                     }
                 }
                 EntityId::User => {

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -210,12 +210,7 @@ impl DemoChat {
 
         let ui = self.ui_runner();
         spawn(async move {
-            let errors = repo
-                .load()
-                .await
-                .err()
-                .map(|(errors, _)| errors)
-                .unwrap_or_default();
+            let errors = repo.load().await.into_errors();
 
             ui.defer_with_redraw(move |me, _cx, _scope| {
                 let mut chat = me.chat(id!(chat));

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -226,10 +226,10 @@ impl DemoChat {
 
                 for error in errors {
                     messages.write().messages.push(Message {
-                        body: error.to_string(),
-                        is_writing: false,
-                        citations: Vec::new(),
                         from: EntityId::App,
+                        body: error.to_string(),
+                        level: MessageLevel::Error,
+                        ..Default::default()
                     });
                 }
             });

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -229,7 +229,7 @@ impl DemoChat {
                         body: error.to_string(),
                         is_writing: false,
                         citations: Vec::new(),
-                        from: EntityId::User,
+                        from: EntityId::App,
                     });
                 }
             });

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -3,6 +3,7 @@ use moly_kit::utils::asynchronous::spawn;
 use moly_kit::*;
 
 use crate::bot_selector::BotSelectorWidgetExt;
+use crate::tester_client::TesterClient;
 
 const OPEN_AI_KEY: Option<&str> = option_env!("OPEN_AI_KEY");
 const OPEN_ROUTER_KEY: Option<&str> = option_env!("OPEN_ROUTER_KEY");
@@ -110,11 +111,14 @@ impl DemoChat {
                     "Qwen/Qwen2-7B-Instruct",
                 ];
 
+                let tester_whitelist = ["tester"];
+
                 openai_whitelist
                     .iter()
                     .chain(openrouter_whitelist.iter())
                     .chain(ollama_whitelist.iter())
                     .chain(siliconflow_whitelist.iter())
+                    .chain(tester_whitelist.iter())
                     .any(|s| *s == b.id.as_str())
             })
             .collect::<Vec<_>>();
@@ -171,11 +175,12 @@ impl DemoChat {
 
     fn setup_chat_repo(&self) {
         let client = {
-            // let moly = MolyClient::new("http://localhost:8085".into());
-            let ollama = OpenAIClient::new("http://localhost:11434".into());
-
             let mut client = MultiClient::new();
-            // client.add_client(Box::new(moly));
+
+            let tester = TesterClient;
+            client.add_client(Box::new(tester));
+
+            let ollama = OpenAIClient::new("http://localhost:11434".into());
             client.add_client(Box::new(ollama));
 
             // Only add OpenAI client if API key is present

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -228,7 +228,6 @@ impl DemoChat {
                     messages.write().messages.push(Message {
                         from: EntityId::App,
                         body: error.to_string(),
-                        level: MessageLevel::Error,
                         ..Default::default()
                     });
                 }

--- a/moly-mini/src/lib.rs
+++ b/moly-mini/src/lib.rs
@@ -2,4 +2,5 @@ pub mod app;
 mod bot_selector;
 mod demo_chat;
 mod meta;
+mod tester_client;
 mod ui;

--- a/moly-mini/src/tester_client.rs
+++ b/moly-mini/src/tester_client.rs
@@ -1,0 +1,76 @@
+use moly_kit::protocol::*;
+use std::collections::VecDeque;
+
+pub struct TesterClient;
+
+impl BotClient for TesterClient {
+    fn bots(&self) -> MolyFuture<'static, ClientResult<Vec<Bot>>> {
+        let future = futures::future::ready(ClientResult::new_ok(vec![Bot {
+            id: "tester".into(),
+            name: "tester".to_string(),
+            avatar: Picture::Grapheme("T".into()),
+        }]));
+
+        moly_future(future)
+    }
+
+    fn send_stream(
+        &mut self,
+        _bot: &BotId,
+        messages: &[Message],
+    ) -> MolyStream<'static, ClientResult<MessageDelta>> {
+        let mut input = messages
+            .last()
+            .expect("didn't receive any messages")
+            .body
+            .split_whitespace()
+            .map(|b| b.to_lowercase())
+            .collect::<VecDeque<_>>();
+
+        let stream = futures::stream::once(async move {
+            match input.pop_front().as_deref() {
+                Some("say") => {
+                    let body = input.make_contiguous().join(" ");
+                    ClientResult::new_ok(MessageDelta {
+                        body,
+                        ..Default::default()
+                    })
+                }
+                Some("error") => ClientResult::new_err(
+                    ClientError::new(
+                        ClientErrorKind::Unknown,
+                        "User requested a single error".into(),
+                    )
+                    .into(),
+                ),
+                Some("errors") => ClientResult::new_err(vec![
+                    ClientError::new(
+                        ClientErrorKind::Unknown,
+                        "User requested multiple errors".into(),
+                    )
+                    .into(),
+                    ClientError::new(ClientErrorKind::Unknown, "This is another error".into())
+                        .into(),
+                ]),
+                Some("hello") => ClientResult::new_ok(MessageDelta {
+                    body: "world".into(),
+                    ..Default::default()
+                }),
+                Some("ping") => ClientResult::new_ok(MessageDelta {
+                    body: "pong".into(),
+                    ..Default::default()
+                }),
+                _ => ClientResult::new_ok(MessageDelta {
+                    body: "Yeah...".into(),
+                    ..Default::default()
+                }),
+            }
+        });
+
+        moly_stream(stream)
+    }
+
+    fn clone_box(&self) -> Box<dyn BotClient> {
+        Box::new(TesterClient)
+    }
+}

--- a/moly-mini/src/ui.rs
+++ b/moly-mini/src/ui.rs
@@ -59,16 +59,17 @@ impl Widget for Ui {
 
             let messages = std::iter::repeat([
                 Message {
-                    is_writing: false,
-                    body: "Hello".to_string(),
                     from: EntityId::User,
-                    citations: vec![],
+                    body: "Hello".to_string(),
+                    ..Default::default()
                 },
                 Message {
-                    is_writing: false,
-                    body: "World".to_string(),
                     from: EntityId::Bot(bot_id),
-                    citations: vec!["https://github.com/ZhangHanDong/url-preview/issues/2".to_string()],
+                    body: "World".to_string(),
+                    citations: vec![
+                        "https://github.com/ZhangHanDong/url-preview/issues/2".to_string()
+                    ],
+                    ..Default::default()
                 },
             ])
             .take(1)


### PR DESCRIPTION
# Changes
- Define error kinds a client implementation should take into account.
- Flexible error representation, capable of carrying a recovery value alongside multiple errors.
- Adapted code on `moly-kit` and `moly-mini` to handle the basic errors.
- Low effort, `messages.rs` displays `App` massages as errors if they look like `xxx error: xxx`, by adapting `BotLine`, using the bot name to show the error name instead.
- Added a tester client to `moly-mini` to test error handling.
- Some on the go fixes and corrections.

# Manual testing
- If you set wrong api keys, `moly-mini` should show you errors on start.
- Using the `tester` bot which should be default now on `moly-mini`, you can send `error` or `errors` to make the bot answer with one or many errors.

# Screenshot

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/79cde089-bd53-4a75-8c67-700e9ab9cb3b" />

