### PR TITLE
Catch up with Makepad's DSL changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "makepad-code-editor"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-widgets",
 ]
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1736,7 +1736,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1744,7 +1744,9 @@ dependencies = [
  "makepad-platform",
  "makepad-rustybuzz",
  "makepad-vector",
+ "png",
  "sdfer",
+ "ttf-parser 0.25.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-segmentation",
@@ -1753,17 +1755,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1771,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1782,7 +1784,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1792,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1800,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1808,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1818,17 +1820,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -1837,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1845,12 +1847,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -1874,12 +1876,12 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
  "smallvec",
- "ttf-parser",
+ "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -1889,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1897,16 +1899,16 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "resvg",
- "ttf-parser",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1915,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -1929,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -3779,7 +3781,13 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#9a2e03a11848d1a6e9ad7e4a9623bf6bfcb1ceb2"
+source = "git+https://github.com/makepad/makepad?branch=rik#cd17b1e45fca64bcbfc31c3116c8c45638fb5708"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typenum"

--- a/moly-kit/src/widgets/avatar.rs
+++ b/moly-kit/src/widgets/avatar.rs
@@ -19,7 +19,7 @@ live_design! {
             show_bg: true,
             draw_bg: {
                 color: #444D9A,
-                radius: 6,
+                border_radius: 6,
             }
 
             align: {x: 0.5, y: 0.5},

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -35,7 +35,7 @@ live_design! {
         padding: {left: 16, right: 18, top: 18, bottom: 14},
         show_bg: true,
         draw_bg: {
-            radius: 12.0,
+            border_radius: 12.0,
         }
     }
 

--- a/moly-kit/src/widgets/citations.rs
+++ b/moly-kit/src/widgets/citations.rs
@@ -24,12 +24,12 @@ live_design! {
         show_bg: true,
         draw_bg: {
             color: #f2f2f2
-            radius: 0
+            border_radius: 0
         }
         align: {y: 0.5}
         image_wrapper = <RoundedView> {
             draw_bg: {
-                radius: 0
+                border_radius: 0
             },
             align: {y: 0.5, x: 0.5},
             width: 75, height: Fill,

--- a/moly-kit/src/widgets/message_thinking_block.rs
+++ b/moly-kit/src/widgets/message_thinking_block.rs
@@ -36,7 +36,7 @@ live_design! {
         show_bg: true
         draw_bg: {
             color: #e0
-            radius: 5
+            border_radius: 5
         }
 
         thinking_text = <MessageMarkdown> {

--- a/moly-kit/src/widgets/prompt_input.rs
+++ b/moly-kit/src/widgets/prompt_input.rs
@@ -14,9 +14,9 @@ live_design! {
             padding: {top: 8, bottom: 6, left: 4, right: 10}
             draw_bg: {
                 color: #fff,
-                radius: 10.0,
+                border_radius: 10.0,
                 border_color: #D0D5DD,
-                border_width: 1.0,
+                border_size: 1.0,
             }
             center = {
                 text_input = {
@@ -34,7 +34,7 @@ live_design! {
                             return mix(#98A2B3, #000, self.prompt_enabled)
                         }
                     }
-                    draw_selection: {
+                    draw_highlight: {
                         fn pixel(self) -> vec4 {
                             return #bbb;
                         }

--- a/moly-kit/src/widgets/stages_pill_list.rs
+++ b/moly-kit/src/widgets/stages_pill_list.rs
@@ -17,7 +17,7 @@ live_design! {
             flow: Right, spacing: 4
             width: Fit, height: Fit
             padding: {left: 10, right: 10, top: 7, bottom: 7}
-            draw_bg: { color: #f2f2f2, border_color: #f2f2f2, radius: 0, border_width: 2 }
+            draw_bg: { color: #f2f2f2, border_color_1: #f2f2f2, border_radius: 0, border_size: 2 }
             stage_text = <Label> {
                 draw_text: {
                     text_style: {font_size: 10},
@@ -31,7 +31,7 @@ live_design! {
                 draw_bg: {
                     // color: #b33939,
                     color: #c23616
-                    radius: 3,
+                    border_radius: 3,
                 }
             }
         }
@@ -90,7 +90,7 @@ impl Widget for StagesPillList {
                     let darker_color = vec4(0.882, 0.882, 0.882, 1.0);
                     stage_pill.view(id!(wrapper_view)).apply_over(cx, live!{
                         draw_bg: {
-                            border_color: (darker_color)
+                            border_color_1: (darker_color)
                         }
                     });
                 } else {
@@ -98,7 +98,7 @@ impl Widget for StagesPillList {
                     let normal_color = vec4(0.949, 0.949, 0.949, 1.0);
                     stage_pill.view(id!(wrapper_view)).apply_over(cx, live!{
                         draw_bg: {
-                            border_color: (normal_color)
+                            border_color_1: (normal_color)
                         }
                     });
                 }

--- a/moly-mini/src/bot_selector.rs
+++ b/moly-mini/src/bot_selector.rs
@@ -17,9 +17,9 @@ live_design! {
         height: Fit,
         clip = <CachedRoundedView> {
             draw_bg: {
-                border_width: 1.0,
-                border_color: #D0D5DD,
-                radius: 5.0
+                border_size: 1.0,
+                border_color_1: #D0D5DD,
+                border_radius: 5.0
             },
             <View> {
                 show_bg: true,
@@ -48,8 +48,8 @@ live_design! {
                             width: Fill,
                             height: Fill,
                             draw_bg: {
-                                // radius: 0.0,
-                                // border_width: 0.0,
+                                // border_radius: 0.0,
+                                // border_size: 0.0,
                             },
                             draw_text: {
                                 color: #000,

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,9 +74,9 @@ live_design! {
                         show_bg: true,
                         draw_bg: {
                             color: (SIDEBAR_BG_COLOR),
-                            instance radius: 0.0,
+                            instance border_radius: 0.0,
                             border_color: #EAECF0,
-                            border_width: 1.2,
+                            border_size: 1.2,
                         }
 
                         discover_tab = <SidebarMenuButton> {

--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -40,6 +40,16 @@ live_design! {
 
     pub ChatHistory = {{ChatHistory}} <MolyTogglePanel> {
         open_content = {
+
+            draw_bg: {
+                instance opacity: 1.0
+
+                fn pixel(self) -> vec4 {
+                    let color = sample2d_rt(self.image, self.pos * self.scale + self.shift);
+                    return Pal::premul(vec4(color.xyz, color.w * self.opacity))
+                }
+            }
+
             <View> {
                 width: Fill,
                 height: Fill,

--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -66,7 +66,7 @@ live_design! {
     }
 
     CancelButton = <EditActionButton> {
-        draw_bg: { border_color: #D0D5DD, border_width: 1.0, color: #fff }
+        draw_bg: { border_color_1: #D0D5DD, border_size: 1.0, color: #fff }
 
         draw_text: {
             text_style: <REGULAR_FONT>{font_size: 9},
@@ -90,8 +90,8 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #0000
-                border_width: 0
-                radius: 5
+                border_size: 0
+                border_radius: 5
             }
         }
 
@@ -107,8 +107,8 @@ live_design! {
             draw_bg: {
                 instance down: 0.0,
                 color: #0000
-                border_width: 0
-                radius: 5
+                border_size: 0
+                border_radius: 5
             }
 
             <View> {
@@ -200,7 +200,7 @@ live_design! {
                     padding: { top: 0, right: 4, bottom: 6, left: 4 }
 
                     draw_bg: {
-                        radius: 5
+                        border_radius: 5
                     }
 
                     draw_text:{

--- a/src/chat/chat_history_card_options.rs
+++ b/src/chat/chat_history_card_options.rs
@@ -25,9 +25,9 @@ live_design! {
 
             draw_bg: {
                 color: #fff,
-                border_width: 1.0,
+                border_size: 1.0,
                 border_color: #D0D5DD,
-                radius: 2.
+                border_radius: 2.
             }
 
             edit_chat_name = <MolyButton> {
@@ -36,8 +36,8 @@ live_design! {
                 padding: { top: 12, right: 12, bottom: 12, left: 12}
 
                 draw_bg: {
-                    border_width: 0,
-                    radius: 0
+                    border_size: 0,
+                    border_radius: 0
                 }
 
                 icon_walk: {width: 12, height: 12}
@@ -66,8 +66,8 @@ live_design! {
                 align: {x: 0.0, y: 0.5}
 
                 draw_bg: {
-                    border_width: 0,
-                    radius: 0
+                    border_size: 0,
+                    border_radius: 0
                 }
 
                 icon_walk: {width: 12, height: 12}

--- a/src/chat/chat_params.rs
+++ b/src/chat/chat_params.rs
@@ -21,10 +21,10 @@ live_design! {
         width: Fill,
         show_bg: true
         draw_bg: {
-            radius: 5.0
+            border_radius: 5.0
             color: #fff
-            border_width: 1.0,
-            border_color: #D9D9D9,
+            border_size: 1.0,
+            border_color_1: #D9D9D9,
         }
         scrolled_content = <ScrollYView> {
             margin: 1,
@@ -78,9 +78,9 @@ live_design! {
                                 height: Fit,
                                 empty_message: "Enter a system prompt"
                                 draw_bg: {
-                                    radius: 0
+                                    border_radius: 0
                                     color: #0000
-                                    border_width: 0
+                                    border_size: 0
                                 }
                                 draw_text: {
                                     text_style: <REGULAR_FONT>{font_size: 10},
@@ -170,9 +170,9 @@ live_design! {
                                     height: Fit,
                                     empty_message: " "
                                     draw_bg: {
-                                        radius: 0,
+                                        border_radius: 0,
                                         color: #0000,
-                                        border_width: 0,
+                                        border_size: 0,
                                     }
                                     draw_text: {
                                         text_style: <REGULAR_FONT>{font_size: 10},
@@ -280,11 +280,11 @@ impl Widget for ChatParams {
             let system_prompt_value = chat.system_prompt.clone().unwrap_or_default();
             system_prompt.set_text(cx, &system_prompt_value);
 
-            // Currently, `selected` and `set_selected` interact with the animator of
+            // Currently, `active` and `set_active` interact with the animator of
             // the widget to do what they do. To avoid some visual issues, we should not
             // trigger the animator unnecessarily. This is a workaround.
-            if stream.selected(cx) != ip.stream {
-                stream.set_selected(cx, ip.stream);
+            if stream.active(cx) != ip.stream {
+                stream.set_active(cx, ip.stream);
             }
         } else {
             self.visible = false;

--- a/src/chat/delete_chat_modal.rs
+++ b/src/chat/delete_chat_modal.rs
@@ -25,7 +25,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3
+                border_radius: 3
             }
 
             <View> {
@@ -96,9 +96,9 @@ live_design! {
                         padding: {top: 10, bottom: 10, left: 14, right: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
-                            border_color: #D0D5DD,
-                            border_width: 1.2,
+                            instance border_radius: 2.0,
+                            border_color_1: #D0D5DD,
+                            border_size: 1.2,
                             color: #fff,
                         }
 
@@ -115,7 +115,7 @@ live_design! {
                         padding: {top: 10, bottom: 10, left: 14, right: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
+                            instance border_radius: 2.0,
                             color: #D92D20,
                         }
 

--- a/src/chat/entity_button.rs
+++ b/src/chat/entity_button.rs
@@ -26,7 +26,7 @@ live_design!(
         cursor: Hand
         show_bg: true,
         draw_bg: {
-            radius: 0,
+            border_radius: 0,
             color: #0000
         }
 

--- a/src/chat/model_info.rs
+++ b/src/chat/model_info.rs
@@ -17,7 +17,7 @@ live_design! {
 
         spacing: 5,
         draw_bg: {
-            radius: 2.0,
+            border_radius: 2.0,
         }
 
         caption = <Label> {
@@ -64,7 +64,7 @@ live_design! {
             draw_bg: {
                 color: #fff,
                 border_color: #B4B4B4,
-                border_width: 1.0,
+                border_size: 1.0,
             }
         }
 

--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -38,7 +38,7 @@ live_design! {
         }
 
         draw_bg: {
-            instance radius: 3.0,
+            instance border_radius: 3.0,
             color: #F9FAFB,
         }
 
@@ -131,10 +131,10 @@ live_design! {
         padding: 5,
 
         draw_bg: {
-            instance radius: 3.0,
+            instance border_radius: 3.0,
             color: #fff,
             border_color: #D0D5DD,
-            border_width: 1.0,
+            border_size: 1.0,
         }
 
         list_container = <View> {

--- a/src/chat/model_selector_loading.rs
+++ b/src/chat/model_selector_loading.rs
@@ -16,7 +16,7 @@ live_design! {
         height: 8,
         show_bg: true,
         draw_bg: {
-            instance radius: 1.0,
+            instance border_radius: 1.0,
             instance dither: 0.9
 
             fn get_color(self) -> vec4 {
@@ -30,15 +30,15 @@ live_design! {
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size)
                 sdf.box(
-                    self.inset.x + self.border_width,
-                    self.inset.y + self.border_width,
-                    self.rect_size.x - (self.inset.x + self.inset.z + self.border_width * 2.0),
-                    self.rect_size.y - (self.inset.y + self.inset.w + self.border_width * 2.0),
-                    max(1.0, self.radius)
+                    self.border_size,
+                    self.border_size,
+                    self.rect_size.x - (self.border_size * 2.0),
+                    self.rect_size.y - (self.border_size * 2.0),
+                    max(1.0, self.border_radius)
                 )
                 sdf.fill_keep(self.get_color())
-                if self.border_width > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_width)
+                if self.border_size > 0.0 {
+                    sdf.stroke(self.get_border_color(), self.border_size)
                 }
                 return sdf.result;
             }

--- a/src/chat/prompt_input.rs
+++ b/src/chat/prompt_input.rs
@@ -44,7 +44,7 @@ live_design! {
         height: 28,
 
         draw_bg: {
-            radius: 6.5,
+            border_radius: 6.5,
             color: #D0D5DD
         }
         icon_walk: {
@@ -76,17 +76,17 @@ live_design! {
                 padding: {bottom: 12.0, top: 12.0, right: 6.0, left: 6.0},
                 margin: {bottom: 10},
                 draw_bg: {
-                    border_width: 1.0,
-                    border_color: #D0D5DD,
+                    border_size: 1.0,
+                    border_color_1: #D0D5DD,
                     color: #fff,
-                    radius: 5.0
+                    border_radius: 5.0
                 }
                 search_input = <MolyTextInput> {
                     width: Fill,
                     margin: {bottom: 4},
                     empty_message: "Search for a model or agent",
                     draw_bg: {
-                        radius: 5.0,
+                        border_radius: 5.0,
                         color: #fff
                     }
                     draw_text: {
@@ -100,9 +100,9 @@ live_design! {
                 padding: {top: 8, bottom: 6, left: 4, right: 10}
                 draw_bg: {
                     color: #fff,
-                    radius: 10.0,
-                    border_color: #D0D5DD,
-                    border_width: 1.0,
+                    border_radius: 10.0,
+                    border_color_1: #D0D5DD,
+                    border_size: 1.0,
                 }
 
                 top = {
@@ -115,7 +115,7 @@ live_design! {
                         padding: {left: 10, right: 10, top: 8, bottom: 8}
                         draw_bg: {
                             color: #F2F4F7,
-                            radius: 10.0,
+                            border_radius: 10.0,
                         }
                         agent_avatar = <ChatAgentAvatar> {
                             width: Fit,
@@ -161,7 +161,7 @@ live_design! {
                         width: Fill,
                         empty_message: "Start typing",
                         draw_bg: {
-                            radius: 10.0
+                            border_radius: 10.0
                             color: #fff
                         }
                         draw_text: {

--- a/src/chat/shared.rs
+++ b/src/chat/shared.rs
@@ -16,7 +16,7 @@ live_design! {
         show_bg: true,
         draw_bg: {
             color: #444D9A,
-            radius: 6,
+            border_radius: 6,
         }
 
         align: {x: 0.5, y: 0.5},

--- a/src/landing/download_item.rs
+++ b/src/landing/download_item.rs
@@ -28,7 +28,7 @@ live_design! {
 
         spacing: 5,
         draw_bg: {
-            radius: 2.0,
+            border_radius: 2.0,
         }
 
         caption = <Label> {
@@ -116,7 +116,7 @@ live_design! {
                 height: Fill,
                 draw_bg: {
                     color: #D9D9D9,
-                    radius: 2.0,
+                    border_radius: 2.0,
                 }
             }
 
@@ -125,7 +125,7 @@ live_design! {
                 height: Fill,
                 draw_bg: {
                     color: #099250,
-                    radius: 2.0,
+                    border_radius: 2.0,
                 }
             }
         }
@@ -136,11 +136,11 @@ live_design! {
         height: 40,
 
         draw_bg: {
-            border_color: #EAECF0,
-            border_width: 1.0,
+            border_color_1: #EAECF0,
+            border_size: 1.0,
             color: #fff,
             color_hover: #E2F1F1,
-            radius: 2.0,
+            border_radius: 2.0,
         }
 
         draw_icon: {
@@ -197,7 +197,7 @@ live_design! {
 
         draw_bg: {
             border_color: #EAECF0,
-            border_width: 1.0,
+            border_size: 1.0,
             color: #fff,
         }
 

--- a/src/landing/model_card.rs
+++ b/src/landing/model_card.rs
@@ -60,7 +60,7 @@ live_design! {
                 draw_bg: {
                     color: #0000,
                     border_color: #98A2B3,
-                    border_width: 1.0,
+                    border_size: 1.0,
                 },
                 attr_name = <Icon> {
                     draw_icon: {
@@ -90,7 +90,7 @@ live_design! {
                 draw_bg: {
                     color: #0000,
                     border_color: #98A2B3,
-                    border_width: 1.0,
+                    border_size: 1.0,
                 },
                 attr_name = <Icon> {
                     draw_icon: {
@@ -122,7 +122,7 @@ live_design! {
                     draw_bg: {
                         color: #0000,
                         border_color: #98A2B3,
-                        border_width: 1.0,
+                        border_size: 1.0,
                     },
                     attr_name = {
                         draw_text: { color: #000 }
@@ -230,7 +230,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3
+                border_radius: 3
             }
 
             <View> {
@@ -303,10 +303,10 @@ live_design! {
             height: Fit,
 
             draw_bg: {
-                instance radius: 3.0,
+                instance border_radius: 3.0,
                 color: #F9FAFB,
                 border_color: #DFDFDF,
-                border_width: 1.0,
+                border_size: 1.0,
             }
 
             flow: Down,

--- a/src/landing/model_files.rs
+++ b/src/landing/model_files.rs
@@ -24,17 +24,17 @@ live_design! {
         label_walk: { margin: 0 }
         draw_text: {
             text_style: <BOLD_FONT>{font_size: 9},
-            color_selected: #475467;
-            color_unselected: #475467;
-            color_unselected_hover: #173437;
+            color_active: #475467;
+            color: #475467;
+            color_hover: #173437;
         }
-        draw_radio: {
-            color_unselected: #D0D5DD,
-            color_selected: #fff,
-            color_unselected_hover: #D0D5DD,
-            border_color: #D0D5DD,
-            border_width: 1.0,
-            radius: 7.0
+        draw_bg: {
+            color: #D0D5DD,
+            color_active: #fff,
+            color_hover: #D0D5DD,
+            border_color_1: #D0D5DD,
+            border_size: 1.0,
+            border_radius: 7.0
         }
     }
 
@@ -61,7 +61,7 @@ live_design! {
 
             draw_bg: {
                 color: #D0D5DD
-                radius: 7.0
+                border_radius: 7.0
             }
 
             show_all_button =  <ActionToggleButton> {
@@ -75,7 +75,7 @@ live_design! {
         show_bg: true,
         draw_bg: {
             color: #F2F4F7
-            radius: vec2(3.0, 0.5)
+            border_radius: vec2(3.0, 0.5)
         }
 
         cell1 = {

--- a/src/landing/model_files_item.rs
+++ b/src/landing/model_files_item.rs
@@ -37,7 +37,7 @@ live_design! {
         show_bg: true,
         draw_bg: {
             color: #00f
-            radius: vec2(1.0, 1.0)
+            border_radius: vec2(1.0, 1.0)
         }
 
         cell1 = <View> { width: Fill, height: 56, padding: 10, align: {x: 0.0, y: 0.5} }
@@ -52,7 +52,7 @@ live_design! {
     }
 
     DownloadButton = <ModelCardButton> {
-        draw_bg: { color: #099250, border_color: #099250 }
+        draw_bg: { color: #099250, border_color_1: #099250 }
         text: "Download"
         draw_icon: {
             svg_file: (ICON_DOWNLOAD),
@@ -60,7 +60,7 @@ live_design! {
     }
 
     StartChatButton = <ModelCardButton> {
-        draw_bg: { color: #fff, color_hover: #09925033, border_color: #d0d5dd }
+        draw_bg: { color: #fff, color_hover: #09925033, border_color_1: #d0d5dd }
         text: "Chat with Model"
         draw_text: {
             color: #087443;
@@ -94,7 +94,7 @@ live_design! {
                 height: Fill,
                 draw_bg: {
                     color: #D9D9D9,
-                    radius: 2.5,
+                    border_radius: 2.5,
                 }
             }
 
@@ -102,7 +102,7 @@ live_design! {
                 width: 0,
                 height: Fill,
                 draw_bg: {
-                    radius: 2.5,
+                    border_radius: 2.5,
                 }
             }
         }
@@ -174,9 +174,9 @@ live_design! {
                 padding: {top: 6, bottom: 6, left: 10, right: 10}
 
                 draw_bg: {
-                    instance radius: 2.0,
+                    instance border_radius: 2.0,
                     border_color: #B4B4B4,
-                    border_width: 0.5,
+                    border_size: 0.5,
                     color: #FFF,
                 }
 

--- a/src/landing/model_files_tags.rs
+++ b/src/landing/model_files_tags.rs
@@ -13,7 +13,7 @@ live_design! {
         padding: {top: 6, bottom: 6, left: 10, right: 10}
 
         draw_bg: {
-            instance radius: 2.0,
+            instance border_radius: 2.0,
             color: #E6F1EC,
         }
 

--- a/src/landing/model_list.rs
+++ b/src/landing/model_list.rs
@@ -22,7 +22,7 @@ live_design! {
         height: 100,
         show_bg: false,
         draw_bg: {
-            radius: 5,
+            border_radius: 5,
             color: #F9FAFB,
         }
         button = <EntityButton> {
@@ -34,7 +34,7 @@ live_design! {
             server_url_visible: true,
 
             draw_bg: {
-                radius: 5,
+                border_radius: 5,
             }
             agent_avatar = {
                 image = {

--- a/src/landing/search_bar.rs
+++ b/src/landing/search_bar.rs
@@ -74,9 +74,9 @@ live_design! {
             align: {x: 0.0, y: 0.5},
 
             draw_bg: {
-                radius: 9.0,
+                border_radius: 9.0,
                 border_color: #D0D5DD,
-                border_width: 1.0,
+                border_size: 1.0,
             }
 
             <Icon> {

--- a/src/landing/search_loading.rs
+++ b/src/landing/search_loading.rs
@@ -14,7 +14,7 @@ live_design! {
         width: 28
         height: 28
         draw_bg: {
-            radius: 14.0
+            border_radius: 14.0
             fn get_color(self) -> vec4 {
                 let top_color = #E6F2D8;
                 let bottom_color = #A4E0EF;
@@ -55,12 +55,12 @@ live_design! {
                 start = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {content = { circle1 = { draw_bg: {radius: 1.0} }}}
+                    apply: {content = { circle1 = { draw_bg: {border_radius: 1.0} }}}
                 }
                 run = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {content = { circle1 = { draw_bg: {radius: 14.0} }}}
+                    apply: {content = { circle1 = { draw_bg: {border_radius: 14.0} }}}
                 }
             }
 
@@ -69,12 +69,12 @@ live_design! {
                 start = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {content = { circle2 = { draw_bg: {radius: 1.0} }}}
+                    apply: {content = { circle2 = { draw_bg: {border_radius: 1.0} }}}
                 }
                 run = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {content = { circle2 = { draw_bg: {radius: 14.0} }}}
+                    apply: {content = { circle2 = { draw_bg: {border_radius: 14.0} }}}
                 }
             }
 
@@ -83,12 +83,12 @@ live_design! {
                 start = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {content = { circle3 = { draw_bg: {radius: 1.0} }}}
+                    apply: {content = { circle3 = { draw_bg: {border_radius: 1.0} }}}
                 }
                 run = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {content = { circle3 = { draw_bg: {radius: 14.0} }}}
+                    apply: {content = { circle3 = { draw_bg: {border_radius: 14.0} }}}
                 }
             }
         }

--- a/src/landing/shared.rs
+++ b/src/landing/shared.rs
@@ -26,7 +26,7 @@ live_design! {
                             self.hover
                         ),
                         MODEL_LINK_FONT_COLOR,
-                        self.pressed
+                        self.down
                     )
                 }
             }
@@ -48,7 +48,7 @@ live_design! {
 
         spacing: 5,
         draw_bg: {
-            instance radius: 3.0,
+            instance border_radius: 3.0,
         }
 
         attr_name = <Label> {

--- a/src/landing/sorting.rs
+++ b/src/landing/sorting.rs
@@ -19,13 +19,9 @@ live_design! {
             text_style: <BOLD_FONT> { font_size: 9 },
             fn get_color(self) -> vec4 {
                 return mix(
-                    mix(
-                        #000,
-                        #000,
-                        self.focus
-                    ),
                     #000,
-                    self.pressed
+                    #000,
+                    self.focus
                 )
             }
         }
@@ -35,10 +31,9 @@ live_design! {
 
             draw_bg: {
                 color: #fff,
-                border_width: 1.5,
-                //border_color: #EAECF0,
-                radius: 4.0
-                blur: 0.0
+                border_size: 1.5,
+                //border_color_1: #EAECF0,
+                border_radius: 4.0
             }
 
             menu_item: {
@@ -49,14 +44,14 @@ live_design! {
 
                 draw_bg: {
                     color: #fff,
-                    color_selected: #eee9,
+                    color_active: #eee9,
 
                     fn pixel(self) -> vec4 {
                         let sdf = Sdf2d::viewport(self.pos * self.rect_size);
 
                         sdf.clear(mix(
                             self.color,
-                            self.color_selected,
+                            self.color_active,
                             self.hover
                         ))
 
@@ -66,15 +61,15 @@ live_design! {
                         sdf.move_to(c.x - sz + dx * 0.5, c.y - sz + dx);
                         sdf.line_to(c.x, c.y + sz);
                         sdf.line_to(c.x + sz * 2.0, c.y - sz * 2.0);
-                        sdf.stroke(mix(#0000, #0, self.selected), 1.0);
+                        sdf.stroke(mix(#0000, #0, self.active), 1.0);
 
                         return sdf.result;
                     }
                 }
 
-                draw_name: {
+                draw_text: {
                     text_style: <BOLD_FONT> { font_size: 9 }
-                    instance selected: 0.0
+                    instance active: 0.0
                     instance hover: 0.0
                     fn get_color(self) -> vec4 {
                         return #000;

--- a/src/my_models/delete_model_modal.rs
+++ b/src/my_models/delete_model_modal.rs
@@ -27,7 +27,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3
+                border_radius: 3
             }
 
             <View> {
@@ -98,9 +98,9 @@ live_design! {
                         padding: {top: 10, bottom: 10, left: 14, right: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
-                            border_color: #D0D5DD,
-                            border_width: 1.2,
+                            instance border_radius: 2.0,
+                            border_color_1: #D0D5DD,
+                            border_size: 1.2,
                             color: #fff,
                         }
 
@@ -117,7 +117,7 @@ live_design! {
                         padding: {top: 10, bottom: 10, left: 14, right: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
+                            instance border_radius: 2.0,
                             color: #D92D20,
                         }
 

--- a/src/my_models/downloaded_files_row.rs
+++ b/src/my_models/downloaded_files_row.rs
@@ -26,7 +26,7 @@ live_design! {
         height: 40
 
         draw_bg: {
-            border_color: #ccc,
+            border_color_1: #ccc,
         }
 
         draw_icon: {

--- a/src/my_models/model_info_modal.rs
+++ b/src/my_models/model_info_modal.rs
@@ -36,7 +36,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3
+                border_radius: 3
             }
 
             <View> {
@@ -125,9 +125,9 @@ live_design! {
                         icon_walk: {width: 14, height: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
-                            border_color: #D0D5DD,
-                            border_width: 1.2,
+                            instance border_radius: 2.0,
+                            border_color_1: #D0D5DD,
+                            border_size: 1.2,
                             color: #EDFCF2,
                         }
 
@@ -143,9 +143,9 @@ live_design! {
                         padding: {top: 10, bottom: 10, left: 14, right: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
-                            border_color: #D0D5DD,
-                            border_width: 1.2,
+                            instance border_radius: 2.0,
+                            border_color_1: #D0D5DD,
+                            border_size: 1.2,
                             color: #F5FEFF,
                         }
 

--- a/src/my_models/my_models_screen.rs
+++ b/src/my_models/my_models_screen.rs
@@ -23,7 +23,7 @@ live_design! {
         padding: {top: 6, bottom: 6, left: 14, right: 14}
 
         draw_bg: {
-            radius: 2.0,
+            border_radius: 2.0,
             color: #FEFEFE,
         }
 
@@ -48,7 +48,7 @@ live_design! {
         padding: {top: 6, bottom: 6, left: 14, right: 14}
 
         draw_bg: {
-            radius: 2.0,
+            border_radius: 2.0,
             color: #FEFEFE,
             color_hover: #999,
         }
@@ -81,9 +81,9 @@ live_design! {
         align: {x: 0.0, y: 0.5},
 
         draw_bg: {
-            radius: 9.0,
+            border_radius: 9.0,
             border_color: #D0D5DD,
-            border_width: 1.0,
+            border_size: 1.0,
         }
 
         <Icon> {

--- a/src/settings/add_provider_modal.rs
+++ b/src/settings/add_provider_modal.rs
@@ -21,8 +21,8 @@ live_design! {
 
     ModalTextInput = <MolyTextInput> {
         draw_bg: {
-            border_width: 1.0
-            border_color: #ddd
+            border_size: 1.0
+            border_color_1: #ddd
         }
         draw_text: {
             text_style: <REGULAR_FONT>{font_size: 12},
@@ -50,7 +50,7 @@ live_design! {
                 return mix(
                     #2,
                     #x0,
-                    self.pressed
+                    self.down
                 )
             }
         }
@@ -65,13 +65,13 @@ live_design! {
                 align: { y: 0.5 }
                 padding: {left: 15, right: 15, top: 10, bottom: 10}
                 
-                draw_name: {
+                draw_text: {
                     fn get_color(self) -> vec4 {
                         return mix(
                             mix(
                                 #3,
                                 #x0,
-                                self.selected
+                                self.active
                             ),
                             #x0,
                             self.hover
@@ -81,20 +81,20 @@ live_design! {
                 
                 draw_bg: {
                     instance color: #f //(THEME_COLOR_FLOATING_BG)
-                    instance color_selected: #f2 //(THEME_COLOR_CTRL_HOVER)
+                    instance color_active: #f2 //(THEME_COLOR_CTRL_HOVER)
                 }
             }
             
             draw_bg: {
                 instance color: #f9 //(THEME_COLOR_FLOATING_BG)
-                border_width: 1.0
+                border_size: 1.0
             }
         }
     }
 
     CustomProviderRadio = <RadioButton> {
         draw_text: {               
-            uniform color_unselected: #x0
+            uniform color: #x0
             text_style: <REGULAR_FONT>{font_size: 12},
         }
     }
@@ -113,7 +113,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3
+                border_radius: 3
             }
 
             header =<View> {
@@ -229,7 +229,7 @@ live_design! {
                         height: 40
                         padding: {left: 20, right: 20, top: 0, bottom: 0}
                         text: "Add Provider"
-                        draw_bg: { color: #099250, border_color: #099250 }
+                        draw_bg: { color: #099250, border_color_1: #099250 }
                     }
                 }
             }

--- a/src/settings/delete_server_modal.rs
+++ b/src/settings/delete_server_modal.rs
@@ -25,7 +25,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3
+                border_radius: 3
             }
 
             <View> {
@@ -96,9 +96,9 @@ live_design! {
                         padding: {top: 10, bottom: 10, left: 14, right: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
-                            border_color: #D0D5DD,
-                            border_width: 1.2,
+                            instance border_radius: 2.0,
+                            border_color_1: #D0D5DD,
+                            border_size: 1.2,
                             color: #fff,
                         }
 
@@ -115,7 +115,7 @@ live_design! {
                         padding: {top: 10, bottom: 10, left: 14, right: 14}
 
                         draw_bg: {
-                            instance radius: 2.0,
+                            instance border_radius: 2.0,
                             color: #D92D20,
                         }
 

--- a/src/settings/moly_server_settings.rs
+++ b/src/settings/moly_server_settings.rs
@@ -90,8 +90,8 @@ live_design! {
                         height: Fit
 
                         draw_bg: {
-                            border_width: 1,
-                            radius: 3
+                            border_size: 1,
+                            border_radius: 3
                         }
 
                         margin: {bottom: 4}

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -172,7 +172,7 @@ live_design! {
                         height: 30
                         padding: {left: 20, right: 20, top: 0, bottom: 0}
                         text: "Save"
-                        draw_bg: { color: #099250, border_color: #099250 }
+                        draw_bg: { color: #099250, border_color_1: #099250 }
                     }
                 }
                 <View> {
@@ -222,7 +222,7 @@ live_design! {
                     draw_text: {
                         text_style: <BOLD_FONT>{font_size: 10}
                     }
-                    draw_bg: { color: #f00, border_color: #f00 }
+                    draw_bg: { color: #f00, border_color_1: #f00 }
                 }
             }
         }
@@ -269,7 +269,7 @@ impl Widget for ProviderView {
 
                         let name = models[item_id].human_readable_name();
                         item.label(id!(model_name)).set_text(cx, &name);
-                        item.check_box(id!(enabled_switch)).set_selected(cx, models[item_id].enabled);
+                        item.check_box(id!(enabled_switch)).set_active(cx, models[item_id].enabled);
 
                         item.as_model_entry().set_model_name(&models[item_id].name);
                         item.draw_all(cx, scope);
@@ -365,7 +365,7 @@ impl WidgetMatchEvent for ProviderView {
             // Fetch the models from the provider
             store.chats.test_provider_and_fetch_models(&self.provider.url);
             // Update the provider enabled switch
-            self.check_box(id!(provider_enabled_switch)).set_selected(cx, true);
+            self.check_box(id!(provider_enabled_switch)).set_active(cx, true);
             // Update the UI
             self.update_connection_status(cx);
             self.redraw(cx);
@@ -407,7 +407,7 @@ impl ProviderViewRef {
 
             inner.text_input(id!(api_host)).set_text(cx, &provider.url);
             inner.label(id!(name)).set_text(cx, &provider.name);
-            inner.check_box(id!(provider_enabled_switch)).set_selected(cx, provider.enabled);
+            inner.check_box(id!(provider_enabled_switch)).set_active(cx, provider.enabled);
 
             if provider.was_customly_added {
                 inner.view(id!(remove_provider_view)).set_visible(cx, true);

--- a/src/settings/providers.rs
+++ b/src/settings/providers.rs
@@ -108,10 +108,10 @@ live_design! {
                     padding: {left: 10, right: 10, bottom: 5, top: 5}
                     margin: {right: 10}
                     draw_bg: {
-                        radius: 5
+                        border_radius: 5
                         color: #81cca1
                         border_color: #357852
-                        border_width: 1.2
+                        border_size: 1.2
                     }
                     status_label = <Label> {
                         text: "ON"
@@ -147,9 +147,9 @@ live_design! {
             padding: {left: 30, right: 30, bottom: 10, top: 10}
             draw_bg: {
                 color: #fff
-                radius: 5
+                border_radius: 5
                 border_color: #ddd
-                border_width: 1
+                border_size: 1
             }
             <Label> {
                 text: "+"

--- a/src/shared/desktop_buttons.rs
+++ b/src/shared/desktop_buttons.rs
@@ -18,7 +18,7 @@ live_design! {
             instance close_pressed_color: #c00
 
             fn get_bg_color(self, base_color: vec4, hover_color: vec4, pressed_color: vec4) -> vec4 {
-                return mix(base_color, mix(hover_color, pressed_color, self.pressed), self.hover);
+                return mix(base_color, mix(hover_color, pressed_color, self.down), self.hover);
             }
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
@@ -61,7 +61,7 @@ live_design! {
                         return sdf.result;
                     }
                     DesktopButtonType::XRMode => {
-                        sdf.clear(mix(THEME_COLOR_APP_CAPTION_BAR, mix(#0aa, #077, self.pressed), self.hover));
+                        sdf.clear(mix(THEME_COLOR_APP_CAPTION_BAR, mix(#0aa, #077, self.down), self.hover));
                         let w = 12.;
                         let h = 8.;
                         sdf.box(c.x - w, c.y - h, 2. * w, 2. * h, 2.);
@@ -78,7 +78,7 @@ live_design! {
                     }
                     DesktopButtonType::Fullscreen => {
                         sz = 8.;
-                        sdf.clear(mix(#3, mix(#6, #9, self.pressed), self.hover));
+                        sdf.clear(mix(#3, mix(#6, #9, self.down), self.hover));
                         sdf.rect(c.x - sz, c.y - sz, 2. * sz, 2. * sz);
                         sdf.rect(c.x - sz + 1.5, c.y - sz + 1.5, 2. * (sz - 1.5), 2. * (sz - 1.5));
                         sdf.subtract();

--- a/src/shared/download_notification_popup.rs
+++ b/src/shared/download_notification_popup.rs
@@ -32,7 +32,7 @@ live_design! {
                         self.hover
                     ),
                     PRIMARY_LINK_FONT_COLOR,
-                    self.pressed
+                    self.down
                 )
             }
         }
@@ -51,7 +51,7 @@ live_design! {
                         self.hover
                     ),
                     SECONDARY_LINK_FONT_COLOR,
-                    self.pressed
+                    self.down
                 )
             }
         }
@@ -70,7 +70,7 @@ live_design! {
             instance border_radius: 4.0
             fn pixel(self) -> vec4 {
                 let border_color = #d4;
-                let border_width = 1;
+                let border_size = 1;
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                 let body = #fff
 
@@ -85,7 +85,7 @@ live_design! {
 
                 sdf.stroke(
                     border_color,
-                    border_width
+                    border_size
                 )
                 return sdf.result
             }

--- a/src/shared/external_link.rs
+++ b/src/shared/external_link.rs
@@ -25,7 +25,7 @@ live_design! {
                             self.hover
                         ),
                         MODEL_LINK_FONT_COLOR,
-                        self.pressed
+                        self.down
                     )
                 }
             }

--- a/src/shared/tooltip.rs
+++ b/src/shared/tooltip.rs
@@ -34,9 +34,9 @@ live_design! {
 
                 draw_bg: {
                     color: #fff,
-                    border_width: 1.0,
-                    border_color: #D0D5DD,
-                    radius: 2.
+                    border_size: 1.0,
+                    border_color_1: #D0D5DD,
+                    border_radius: 2.
                 }
 
                 tooltip_label = <Label> {

--- a/src/shared/widgets.rs
+++ b/src/shared/widgets.rs
@@ -31,7 +31,7 @@ live_design! {
             instance opacity: 1.0
 
             fn pixel(self) -> vec4 {
-                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift) + vec4(self.marked, 0.0, 0.0, 0.0);
+                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift);
                 return Pal::premul(vec4(color.xyz, color.w * self.opacity))
             }
         }
@@ -44,7 +44,7 @@ live_design! {
 
         spacing: 5,
         draw_bg: {
-            instance radius: 2.0,
+            instance border_radius: 2.0,
         }
 
         attr_name = <Label> {
@@ -72,13 +72,13 @@ live_design! {
         icon_walk: {margin: 0, width: 30, height: 30}
         label_walk: {margin: 0}
 
-        draw_radio: {
+        draw_bg: {
             radio_type: Tab,
 
-            instance border_width: 0.0
-            instance border_color: #0000
+            instance border_size: 0.0
+            instance border_color_1: #0000
             instance inset: vec4(0.0, 0.0, 0.0, 0.0)
-            instance radius: 2.5
+            instance border_radius: 2.5
 
             fn get_color(self) -> vec4 {
                 return mix(
@@ -88,62 +88,62 @@ live_design! {
                         self.hover
                     ),
                     (SIDEBAR_BG_COLOR_SELECTED),
-                    self.selected
+                    self.active
                 )
             }
 
             fn get_border_color(self) -> vec4 {
-                return self.border_color
+                return self.border_color_1
             }
 
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size)
                 sdf.box(
-                    self.inset.x + self.border_width,
-                    self.inset.y + self.border_width,
-                    self.rect_size.x - (self.inset.x + self.inset.z + self.border_width * 2.0),
-                    self.rect_size.y - (self.inset.y + self.inset.w + self.border_width * 2.0),
-                    max(1.0, self.radius)
+                    self.inset.x + self.border_size,
+                    self.inset.y + self.border_size,
+                    self.rect_size.x - (self.inset.x + self.inset.z + self.border_size * 2.0),
+                    self.rect_size.y - (self.inset.y + self.inset.w + self.border_size * 2.0),
+                    max(1.0, self.border_radius)
                 )
                 sdf.fill_keep(self.get_color())
-                if self.border_width > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_width)
+                if self.border_size > 0.0 {
+                    sdf.stroke(self.get_border_color(), self.border_size)
                 }
                 return sdf.result;
             }
         }
 
         draw_text: {
-            color_unselected: (SIDEBAR_FONT_COLOR)
-            color_unselected_hover: (SIDEBAR_FONT_COLOR_HOVER)
-            color_selected: (SIDEBAR_FONT_COLOR_SELECTED)
+            color: (SIDEBAR_FONT_COLOR)
+            color_hover: (SIDEBAR_FONT_COLOR_HOVER)
+            color_active: (SIDEBAR_FONT_COLOR_SELECTED)
 
             fn get_color(self) -> vec4 {
                 return mix(
                     mix(
-                        self.color_unselected,
-                        self.color_unselected_hover,
+                        self.color,
+                        self.color_hover,
                         self.hover
                     ),
-                    self.color_selected,
-                    self.selected
+                    self.color_active,
+                    self.active
                 )
             }
         }
 
         draw_icon: {
-            instance color_unselected: (SIDEBAR_FONT_COLOR)
-            instance color_unselected_hover: (SIDEBAR_FONT_COLOR_HOVER)
-            instance color_selected: (SIDEBAR_FONT_COLOR_SELECTED)
+            instance color: (SIDEBAR_FONT_COLOR)
+            instance color_hover: (SIDEBAR_FONT_COLOR_HOVER)
+            instance color_active: (SIDEBAR_FONT_COLOR_SELECTED)
             fn get_color(self) -> vec4 {
                 return mix(
                     mix(
-                        self.color_unselected,
-                        self.color_unselected_hover,
+                        self.color,
+                        self.color_hover,
                         self.hover
                     ),
-                    self.color_selected,
-                    self.selected
+                    self.color_active,
+                    self.active
                 )
             }
         }
@@ -155,31 +155,31 @@ live_design! {
         draw_bg: {
             instance color: #0000
             instance color_hover: #fff
-            instance border_width: 1.0
-            instance border_color: #0000
+            instance border_size: 1.0
+            instance border_color_1: #0000
             instance border_color_hover: #fff
-            instance radius: 2.5
+            instance border_radius: 2.5
 
             fn get_color(self) -> vec4 {
                 return mix(self.color, mix(self.color, self.color_hover, 0.2), self.hover)
             }
 
             fn get_border_color(self) -> vec4 {
-                return mix(self.border_color, mix(self.border_color, self.border_color_hover, 0.2), self.hover)
+                return mix(self.border_color_1, mix(self.border_color_1, self.border_color_hover, 0.2), self.hover)
             }
 
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size)
                 sdf.box(
-                    self.border_width,
-                    self.border_width,
-                    self.rect_size.x - (self.border_width * 2.0),
-                    self.rect_size.y - (self.border_width * 2.0),
-                    max(1.0, self.radius)
+                    self.border_size,
+                    self.border_size,
+                    self.rect_size.x - (self.border_size * 2.0),
+                    self.rect_size.y - (self.border_size * 2.0),
+                    max(1.0, self.border_radius)
                 )
                 sdf.fill_keep(self.get_color())
-                if self.border_width > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_width)
+                if self.border_size > 0.0 {
+                    sdf.stroke(self.get_border_color(), self.border_size)
                 }
                 return sdf.result;
             }
@@ -241,28 +241,26 @@ live_design! {
     pub MolyRadioButtonTab = <RadioButtonTab> {
         padding: 10,
 
-        draw_radio: {
-            uniform radius: 3.0
-            uniform border_width: 0.0
-            instance color_unselected: (THEME_COLOR_TEXT_DEFAULT)
-            instance color_unselected_hover: (THEME_COLOR_TEXT_HOVER)
-            instance color_selected: (THEME_COLOR_TEXT_SELECTED)
-            instance border_color: (THEME_COLOR_TEXT_SELECTED)
+        draw_bg: {
+            uniform border_radius: 3.0
+            uniform border_size: 0.0
+            instance color: (THEME_COLOR_TEXT)
+            instance color_hover: (THEME_COLOR_TEXT_HOVER)
 
             fn get_color(self) -> vec4 {
                 return mix(
                     mix(
-                        self.color_unselected,
-                        self.color_unselected_hover,
+                        self.color,
+                        self.color_hover,
                         self.hover
                     ),
-                    self.color_selected,
-                    self.selected
+                    self.color_active,
+                    self.active
                 )
             }
 
             fn get_border_color(self) -> vec4 {
-                return self.border_color;
+                return self.border_color_1;
             }
 
             fn pixel(self) -> vec4 {
@@ -270,15 +268,15 @@ live_design! {
                 match self.radio_type {
                     RadioType::Tab => {
                         sdf.box(
-                            self.border_width,
-                            self.border_width,
-                            self.rect_size.x - (self.border_width * 2.0),
-                            self.rect_size.y - (self.border_width * 2.0),
-                            max(1.0, self.radius)
+                            self.border_size,
+                            self.border_size,
+                            self.rect_size.x - (self.border_size * 2.0),
+                            self.rect_size.y - (self.border_size * 2.0),
+                            max(1.0, self.border_radius)
                         )
                         sdf.fill_keep(self.get_color())
-                        if self.border_width > 0.0 {
-                            sdf.stroke(self.get_border_color(), self.border_width)
+                        if self.border_size > 0.0 {
+                            sdf.stroke(self.get_border_color(), self.border_size)
                         }
                     }
                 }
@@ -290,12 +288,12 @@ live_design! {
             fn get_color(self) -> vec4 {
                 return mix(
                     mix(
-                        self.color_unselected,
-                        self.color_unselected_hover,
+                        self.color,
+                        self.color_hover,
                         self.hover
                     ),
-                    self.color_selected,
-                    self.selected
+                    self.color_active,
+                    self.active
                 )
             }
         }
@@ -330,7 +328,7 @@ live_design! {
         }
 
         // TODO find a way to override colors
-        draw_selection: {
+        draw_highlight: {
             instance hover: 0.0
             instance focus: 0.0
             uniform border_radius: 2.0
@@ -350,9 +348,9 @@ live_design! {
 
         draw_bg: {
             color: #fff
-            instance radius: 2.0
-            instance border_width: 0.0
-            instance border_color: #3
+            instance border_radius: 2.0
+            instance border_size: 0.0
+            instance border_color_1: #3
             instance inset: vec4(0.0, 0.0, 0.0, 0.0)
 
             fn get_color(self) -> vec4 {
@@ -360,21 +358,21 @@ live_design! {
             }
 
             fn get_border_color(self) -> vec4 {
-                return self.border_color
+                return self.border_color_1
             }
 
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size)
                 sdf.box(
-                    self.inset.x + self.border_width,
-                    self.inset.y + self.border_width,
-                    self.rect_size.x - (self.inset.x + self.inset.z + self.border_width * 2.0),
-                    self.rect_size.y - (self.inset.y + self.inset.w + self.border_width * 2.0),
-                    max(1.0, self.radius)
+                    self.inset.x + self.border_size,
+                    self.inset.y + self.border_size,
+                    self.rect_size.x - (self.inset.x + self.inset.z + self.border_size * 2.0),
+                    self.rect_size.y - (self.inset.y + self.inset.w + self.border_size * 2.0),
+                    max(1.0, self.border_radius)
                 )
                 sdf.fill_keep(self.get_color())
-                if self.border_width > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_width)
+                if self.border_size > 0.0 {
+                    sdf.stroke(self.get_border_color(), self.border_size)
                 }
                 return sdf.result;
             }
@@ -435,12 +433,12 @@ live_design! {
         }
     }
 
-    pub MolySwitch = <CheckBoxToggle> {
+    pub MolySwitch = <Toggle> {
         // U+200e as text.
         // Nasty trick cause not setting `text` nor using a simple space works to
         // render the widget without label.
         text:"‎"
-        draw_check: {
+        draw_bg: {
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size)
                 let pill_padding = 2.0;
@@ -452,18 +450,18 @@ live_design! {
 
                 // Left side of the pill
                 sdf.circle(pill_radius, pill_radius, pill_radius);
-                sdf.fill(mix(pill_color_off, pill_color_on, self.selected));
+                sdf.fill(mix(pill_color_off, pill_color_on, self.active));
 
                 // Right side of the pill
                 sdf.circle(self.rect_size.x - pill_radius, pill_radius, pill_radius);
-                sdf.fill(mix(pill_color_off, pill_color_on, self.selected));
+                sdf.fill(mix(pill_color_off, pill_color_on, self.active));
 
                 // The union/middle of the pill
                 sdf.rect(pill_radius, 0.0, self.rect_size.x - 2.0 * pill_radius, self.rect_size.y);
-                sdf.fill(mix(pill_color_off, pill_color_on, self.selected));
+                sdf.fill(mix(pill_color_off, pill_color_on, self.active));
 
                 // The moving ball
-                sdf.circle(pill_padding + ball_radius + self.selected * (self.rect_size.x - 2.0 * ball_radius - 2.0 * pill_padding), pill_radius, ball_radius);
+                sdf.circle(pill_padding + ball_radius + self.active * (self.rect_size.x - 2.0 * ball_radius - 2.0 * pill_padding), pill_radius, ball_radius);
                 sdf.fill(#fff);
 
                 return sdf.result;


### PR DESCRIPTION
## Makepad DSL changes

### Basic Field Renames

- radius → border_radius
- border_width → border_size
- pressed → down (in Button components)
- selected → active (in general)
- draw_selection → draw_highlight
- draw_name → draw_text
- draw_bar → draw_bg
- draw_radio → draw_bg
- padding_fill → (removed)
- drag_quad → drag_target_preview
- color_unselected → color
- color_unselected_hover → color_hover
- color_selected → color_active
- border_color → border_color[_i] (in most places, besides View and some others, that remained the same)

### Removed Fields

marked (in CachedView shaders - completely remove usage)
keyboard_focus_color (no longer supported)
pointer_hover_color (no longer supported)
inset (no longer supported)

### Theme variable changes
https://publish.obsidian.md/makepad-docs/DSL/Theme+Variable+Names+Cleanup

### New naming system
https://publish.obsidian.md/makepad-docs/DSL/Naming+System