### PR TITLE
Unhashed but composed bot id 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,6 @@ dependencies = [
  "chrono",
  "directories",
  "futures",
- "hex",
  "lipsum",
  "makepad-code-editor",
  "makepad-widgets",
@@ -2091,7 +2090,6 @@ dependencies = [
  "robius-url-handler",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "unicode-segmentation",
  "url",
@@ -3322,17 +3320,6 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,6 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "futures",
- "hex",
  "makepad-code-editor",
  "makepad-widgets",
  "reqwest 0.12.12",
@@ -2112,7 +2111,6 @@ dependencies = [
  "scraper 0.23.1",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "url",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,6 @@ path = "src/main.rs"
 moly-protocol = { git = "https://github.com/moxin-org/moly-server", package = "moly-protocol" }
 url-preview = "0.3.0"
 moly-kit = { path = "./moly-kit", features = ["full"] }
-sha2 = "0.10"
-hex = "0.4"
 
 makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
 makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "rik" }

--- a/moly-kit/Cargo.toml
+++ b/moly-kit/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 futures = "0.3.31"
 url = "2.4.10"
 robius-open = "0.1.1"
-sha2 = "0.10"
-hex = "0.4"
 async-stream = "0.3.6"
 
 makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }

--- a/moly-kit/Cargo.toml
+++ b/moly-kit/Cargo.toml
@@ -14,7 +14,7 @@ makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "ri
 
 reqwest = { version = "0.12.12", features = ["json", "stream"], optional = true }
 scraper = { version = "0.23.1", optional = true }
-serde = { version = "1.0.217", features = ["derive"], optional = true }
+serde = { version = "1.0.217", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.135", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -211,8 +211,6 @@ impl BotClient for OpenAIClient {
                 .iter()
                 .map(|m| Bot {
                     id: BotId::new(&m.id, &inner.url),
-                    model_id: m.id.clone(),
-                    provider_url: inner.url.clone(),
                     name: m.id.clone(),
                     // TODO: Handle this char as a grapheme.
                     avatar: Picture::Grapheme(m.id.chars().next().unwrap().to_string()),
@@ -252,7 +250,7 @@ impl BotClient for OpenAIClient {
             .post(&url)
             .headers(headers)
             .json(&serde_json::json!({
-                "model": bot.model_id.clone(),
+                "model": bot.id.id(),
                 "messages": moly_messages,
                 // Note: o1 only supports 1.0, it will error if other value is used.
                 // "temperature": 0.7,

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -45,10 +45,6 @@ pub enum EntityId {
 pub struct Bot {
     /// Unique internal identifier for the bot across all providers
     pub id: BotId,
-    /// Original model identifier from the provider
-    pub model_id: String,
-    /// Provider URL this bot belongs to
-    pub provider_url: String,
     pub name: String,
     pub avatar: Picture,
 }

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -259,9 +259,6 @@ impl Messages {
                         .expect("no bot client set")
                         .get_bot(id);
 
-                    dbg!(&bot);
-                    dbg!(id);
-
                     let (name, avatar) = bot
                         .as_ref()
                         .map(|b| (b.name.as_str(), Some(b.avatar.clone())))

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -259,6 +259,9 @@ impl Messages {
                         .expect("no bot client set")
                         .get_bot(id);
 
+                    dbg!(&bot);
+                    dbg!(id);
+
                     let (name, avatar) = bot
                         .as_ref()
                         .map(|b| (b.name.as_str(), Some(b.avatar.clone())))

--- a/moly-mini/src/tester_client.rs
+++ b/moly-mini/src/tester_client.rs
@@ -6,7 +6,7 @@ pub struct TesterClient;
 impl BotClient for TesterClient {
     fn bots(&self) -> MolyFuture<'static, ClientResult<Vec<Bot>>> {
         let future = futures::future::ready(ClientResult::new_ok(vec![Bot {
-            id: "tester".into(),
+            id: BotId::new("tester", "tester"),
             model_id: "tester".to_string(),
             provider_url: "tester".to_string(),
             name: "tester".to_string(),

--- a/moly-mini/src/ui.rs
+++ b/moly-mini/src/ui.rs
@@ -55,7 +55,7 @@ impl Widget for Ui {
         self.deref.handle_event(cx, event, scope);
 
         if let Event::Startup = event {
-            let bot_id = BotId::from("idk");
+            let bot_id = BotId::new("unknown_bot", "unknown_provider");
 
             let messages = std::iter::repeat([
                 Message {

--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -8,7 +8,6 @@ use crate::data::filesystem::{read_from_file, write_to_file};
 
 pub type ChatID = u128;
 
-
 #[derive(Debug, Default, Copy, Clone, Serialize, Deserialize)]
 enum TitleState {
     #[default]
@@ -103,8 +102,9 @@ impl Chat {
                 // Fallback to last_used_file_id if last_used_entity is None.
                 // Until this field is removed, we need to keep this logic.
                 let associated_bot = data.associated_bot.or_else(|| {
+                    // TODO: What's the provider here?
                     data.last_used_file_id
-                        .map(|file_id| BotId::from(file_id.as_str()))
+                        .map(|file_id| BotId::new(file_id.as_str(), ""))
                 });
 
                 let chat = Chat {

--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -99,17 +99,9 @@ impl Chat {
             Ok(json) => {
                 let data: ChatData = serde_json::from_str(&json)?;
 
-                // Fallback to last_used_file_id if last_used_entity is None.
-                // Until this field is removed, we need to keep this logic.
-                let associated_bot = data.associated_bot.or_else(|| {
-                    // TODO: What's the provider here?
-                    data.last_used_file_id
-                        .map(|file_id| BotId::new(file_id.as_str(), ""))
-                });
-
                 let chat = Chat {
                     id: data.id,
-                    associated_bot,
+                    associated_bot: data.associated_bot,
                     messages: data.messages,
                     title: data.title,
                     title_state: data.title_state,


### PR DESCRIPTION
# Changes
- Remove `hex` and `sha2` dependencies.
- `BotId`s are still created from a provider (discriminant) and an id from that provider.
  - But now it's not hashed improving debugging as you see these components when printed.
  - Now you can recover these sub components.
- `model_id` and `provider_id` in `Bot` are no longer necessary as they can be accessed like `bot.id.id()` and `bot.id.provider()` when necessary.

# Note about id encoding
In order to allow any characters inside the components of the id, while allowing these components to be rescued, the id is encoded without separator characters. Instead the size of the first component is encoded into the id itself allowing you to directly extract the slice from the string without handling escaping or allocating new strings.

# Note about id composition
Having `bot.id.id()` may seem weird at first but I can't think of other concise name. [LayerId](https://docs.rs/egui/latest/egui/layers/struct.LayerId.html) on egui looks similar. 