### PR TITLE
Remove repo loading errors as chat messages

### DIFF
--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -360,22 +360,11 @@ impl ChatScreen {
 
         let ui = self.ui_runner();
             spawn(async move {
-                let errors = repo.load().await.into_errors();
+                repo.load().await;
 
                 ui.defer_with_redraw(move |me, _cx, _scope| {
                 me.should_load_repo_to_store = true;
                 me.creating_bot_repo = false;
-
-                for error in errors {
-                    me.messages(id!(chat.messages)).write().messages.push(Message {
-                        from: EntityId::App,
-                        content: MessageContent::PlainText {
-                            text: error.to_string(),
-                            citations: Vec::new(),
-                        },
-                        is_writing: false,
-                    });
-                }
             });
         });
     }


### PR DESCRIPTION
Removing the usage of chat messages to report repo loading errors, this is causing some panics when deleting error messages (which should be fixed either way), but we're currently already handling and reporting this kind of errors in the providers dashboard.
In the future we could also report this with popup notifications.