### PR TITLE
Make the model selector overlay the chat

### DIFF
--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -32,7 +32,7 @@ live_design! {
                                 
             show_bg: true,
             draw_bg: {
-                color: #f
+                color: #fefefe
                 uniform border_radius: 5.0
                 uniform border_size: 0.0
                 uniform border_color: #0000

--- a/src/chat/model_selector_item.rs
+++ b/src/chat/model_selector_item.rs
@@ -15,7 +15,6 @@ live_design! {
         draw_bg: {
             instance hover: 0.0,
             instance down: 0.0,
-            color: #fff,
             instance color_hover: #F9FAFB,
 
             fn pixel(self) -> vec4 {

--- a/src/chat/model_selector_list.rs
+++ b/src/chat/model_selector_list.rs
@@ -26,7 +26,7 @@ live_design! {
         section_label_template: <Label> {
             padding: {left: 4, top: 4., bottom: 4.}
             draw_text: {
-                text_style: <REGULAR_FONT>{font_size: 10.0},
+                text_style: <BOLD_FONT>{font_size: 10.0},
                 color: #98A2B3
             }
         }


### PR DESCRIPTION
Makes the model selector overlay the list of options on top of the chat, by using the Modal widget.