### PR TITLE
Move message content out

### DIFF
--- a/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_bot_line.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_bot_line.rs
@@ -81,8 +81,6 @@ impl DeepInquireBotLine {
         let stage_with_completion = stages.iter().find(|stage| stage.completed.is_some());
         if let Some(competion_block) = stage_with_completion {
             self.standard_message_content(id!(completed_block.completed_content))
-                .borrow_mut()
-                .unwrap()
                 .set_content(cx, competion_block.completed.as_ref().unwrap());
         }
     }

--- a/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_bot_line.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_bot_line.rs
@@ -1,6 +1,7 @@
 use super::stages::StagesWidgetExt;
 use crate::deep_inquire::Data;
 use crate::protocol::*;
+use crate::standard_message_content::StandardMessageContentWidgetExt;
 use makepad_widgets::*;
 
 live_design! {
@@ -9,12 +10,13 @@ live_design! {
     use link::shaders::*;
 
     use crate::clients::deep_inquire::widgets::stages::*;
-    use crate::widgets::message_markdown::*;
+    use crate::widgets::standard_message_content::*;
     use crate::widgets::chat_lines::*;
 
     pub DeepInquireBotLine = {{DeepInquireBotLine}} <BotLine> {
         message_section = {
-            bubble = {
+            content_section = {
+                flow: Down,
                 <Label> {
                     text: "Steps"
                     draw_text: {
@@ -28,7 +30,7 @@ live_design! {
                 completed_block = <View> {
                     width: Fill, height: Fit,
                     padding: {right: 18, top: 18, bottom: 14},
-                    completed_markdown = <MessageMarkdown> {}
+                    completed_content = <StandardMessageContent> {}
                 }
             }
         }
@@ -78,16 +80,10 @@ impl DeepInquireBotLine {
         // Check if there is a completion block in any of the stages
         let stage_with_completion = stages.iter().find(|stage| stage.completed.is_some());
         if let Some(competion_block) = stage_with_completion {
-            self.markdown(id!(completed_block.completed_markdown))
-                .set_text(
-                    cx,
-                    &competion_block
-                        .completed
-                        .as_ref()
-                        .unwrap()
-                        .text
-                        .replace("\n\n", "\n\n\u{00A0}\n\n"),
-                );
+            self.standard_message_content(id!(completed_block.completed_content))
+                .borrow_mut()
+                .unwrap()
+                .set_content(cx, competion_block.completed.as_ref().unwrap());
         }
     }
 }

--- a/moly-kit/src/clients/deep_inquire/widgets/stages.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/stages.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use makepad_widgets::*;
 
 use crate::deep_inquire::Stage;
-use crate::widgets::citation_list::CitationListWidgetRefExt;
+use crate::standard_message_content::StandardMessageContentWidgetRefExt;
 
 live_design! {
     use link::theme::*;
@@ -11,8 +11,7 @@ live_design! {
     use link::widgets::*;
 
     use makepad_code_editor::code_view::CodeView;
-    use crate::widgets::citation_list::*;
-    use crate::widgets::message_markdown::*;
+    use crate::widgets::standard_message_content::*;
 
 
     // A workaround for RoundedShadowView having the border_size defined as a uniform,
@@ -128,21 +127,7 @@ live_design! {
                 color: #003E62
             }
         }
-        content_block_markdown = <MessageMarkdown> {}
-
-        citations_view = <View> {
-            visible: false
-            height: Fit
-            flow: Down, spacing: 10
-            <Label> {
-                draw_text: {
-                    color: #000
-                    text_style: {font_size: 10},
-                }
-                text: "Sources"
-            }
-            citations_list = <CitationList> {}
-        }
+        content_block_content = <StandardMessageContent> {}
     }
 
     StageView = {{StageView}}<View> {
@@ -187,6 +172,7 @@ live_design! {
                     }
                 }
             }
+
             stage_content_preview = <StageBlockBase> {
                 padding: {left: 30}
                 margin: {left: 30}
@@ -409,18 +395,10 @@ impl StageView {
             let writing_content_block = self.view(id!(writing_content_block));
             writing_content_block.set_visible(cx, true);
             writing_content_block
-                .markdown(id!(content_block_markdown))
-                .set_text(cx, &writing.text.replace("\n\n", "\n\n\u{00A0}\n\n"));
-
-            // Set citations from the message
-            if !writing.citations.is_empty() {
-                writing_content_block
-                    .view(id!(citations_view))
-                    .set_visible(cx, true);
-                let citations = writing_content_block.citation_list(id!(citations_list));
-                let mut citations = citations.borrow_mut().unwrap();
-                citations.urls = writing.citations.clone();
-            }
+                .standard_message_content(id!(content_block_content))
+                .borrow_mut()
+                .unwrap()
+                .set_content(cx, writing);
         }
 
         if let Some(stage_preview_text) = stage_preview_text {

--- a/moly-kit/src/clients/deep_inquire/widgets/stages.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/stages.rs
@@ -396,8 +396,6 @@ impl StageView {
             writing_content_block.set_visible(cx, true);
             writing_content_block
                 .standard_message_content(id!(content_block_content))
-                .borrow_mut()
-                .unwrap()
                 .set_content(cx, writing);
         }
 

--- a/moly-kit/src/widgets.rs
+++ b/moly-kit/src/widgets.rs
@@ -6,21 +6,23 @@ mod avatar;
 mod chat_lines;
 mod citation;
 pub(crate) mod citation_list;
+mod message_content_view;
 mod message_loading;
 mod message_markdown;
 mod message_thinking_block;
 
-#[cfg(any(feature = "async-rt", feature = "async-web"))]
-pub mod chat;
 pub mod messages;
-pub mod prompt_input;
-
-#[cfg(any(feature = "async-rt", feature = "async-web"))]
-pub use chat::*;
 pub use messages::*;
+
+pub mod prompt_input;
 pub use prompt_input::*;
 
-use crate::deep_inquire;
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "async-rt", feature = "async-web"))] {
+        pub mod chat;
+        pub use chat::*;
+    }
+}
 
 pub fn live_design(cx: &mut makepad_widgets::Cx) {
     citation::live_design(cx);
@@ -29,8 +31,9 @@ pub fn live_design(cx: &mut makepad_widgets::Cx) {
     message_markdown::live_design(cx);
     message_loading::live_design(cx);
     avatar::live_design(cx);
+    message_content_view::live_design(cx);
     chat_lines::live_design(cx);
-    deep_inquire::widgets::live_design(cx);
+    crate::deep_inquire::widgets::live_design(cx);
     messages::live_design(cx);
     prompt_input::live_design(cx);
     chat::live_design(cx);

--- a/moly-kit/src/widgets.rs
+++ b/moly-kit/src/widgets.rs
@@ -5,11 +5,11 @@
 mod avatar;
 mod chat_lines;
 mod citation;
-pub(crate) mod citation_list;
+mod citation_list;
 mod message_loading;
 mod message_markdown;
 mod message_thinking_block;
-mod standard_message_content;
+pub(crate) mod standard_message_content;
 
 pub mod messages;
 pub use messages::*;

--- a/moly-kit/src/widgets.rs
+++ b/moly-kit/src/widgets.rs
@@ -6,10 +6,10 @@ mod avatar;
 mod chat_lines;
 mod citation;
 pub(crate) mod citation_list;
-mod message_content_view;
 mod message_loading;
 mod message_markdown;
 mod message_thinking_block;
+mod standard_message_content;
 
 pub mod messages;
 pub use messages::*;
@@ -31,7 +31,7 @@ pub fn live_design(cx: &mut makepad_widgets::Cx) {
     message_markdown::live_design(cx);
     message_loading::live_design(cx);
     avatar::live_design(cx);
-    message_content_view::live_design(cx);
+    standard_message_content::live_design(cx);
     chat_lines::live_design(cx);
     crate::deep_inquire::widgets::live_design(cx);
     messages::live_design(cx);

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -146,11 +146,10 @@ live_design! {
 
     pub LoadingLine = <BotLine> {
         message_section = {
-            bubble = {
-                content_section = <View> {
-                    height: Fit,
-                    loading = <MessageLoading> {}
-                }
+            content_section = <View> {
+                height: Fit,
+                padding: {left: 32}
+                loading = <MessageLoading> {}
             }
         }
     }

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -5,7 +5,7 @@ live_design! {
     use link::widgets::*;
     use link::shaders::*;
 
-    use crate::widgets::message_content_view::*;
+    use crate::widgets::standard_message_content::*;
     use crate::widgets::message_loading::*;
     use crate::widgets::avatar::*;
 
@@ -116,7 +116,7 @@ live_design! {
             content_section = <View> {
                 height: Fit,
                 margin: { left: 32 }
-                content = <MessageContentView> {}
+                content = <StandardMessageContent> {}
             }
             editor = <Editor> { margin: { left: 32 }, visible: false }
         }

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -26,16 +26,6 @@ live_design! {
         }
     }
 
-
-    Bubble = <RoundedView> {
-        height: Fit,
-        padding: {left: 16, right: 18, top: 18, bottom: 14},
-        show_bg: true,
-        draw_bg: {
-            border_radius: 12.0,
-        }
-    }
-
     ActionButton = <Button> {
         width: 14
         height: 14
@@ -125,10 +115,19 @@ live_design! {
             flow: Down,
             height: Fit,
             sender = <Sender> {}
-            bubble = <Bubble> {}
+            text = <View> {
+                flow: Down
+                height: Fit,
+                spacing: 10
+                margin: { left: 32 }
+                thinking_block = <MessageThinkingBlock> {}
+                markdown = <MessageMarkdown> {}
+                citations = <CitationList> { visible: false }
+            }
+            editor = <Editor> { margin: { left: 32 }, visible: false }
         }
         actions_section = <View> {
-            margin: {top: 4, bottom: 10},
+            margin: {left: 32, top: 4, bottom: 10},
             height: 25,
             actions = <Actions> { visible: false }
             edit_actions = <EditActions> { visible: false }
@@ -136,8 +135,6 @@ live_design! {
     }
 
     pub UserLine = <ChatLine> {
-        flow: Down,
-        height: Fit,
         message_section = {
             sender = {
                 avatar = {
@@ -148,53 +145,10 @@ live_design! {
                     }
                 }
             }
-
-            bubble = <Bubble> {
-                flow: Down,
-                padding: 0,
-                margin: {left: 32}
-                text = <View> {
-                    flow: Down
-                    height: Fit,
-                    label = <Label> {
-                        width: Fill,
-                        draw_text: {
-                            color: #000
-                        }
-                    }
-                }
-                editor = <Editor> { visible: false }
-            }
-        }
-        actions_section = {
-            margin: {left: 32}
         }
     }
 
-    pub BotLine = <ChatLine> {
-        flow: Down,
-        height: Fit,
-        message_section = {
-            bubble = <Bubble> {
-                flow: Down,
-                padding: 0,
-                margin: {left: 32}
-                spacing: 10,
-                text = <View> {
-                    flow: Down
-                    height: Fit,
-                    spacing: 10
-                    thinking_block = <MessageThinkingBlock> {}
-                    markdown = <MessageMarkdown> {}
-                }
-                editor = <Editor> { visible: false }
-                citations = <CitationList> { visible: false }
-            }
-        }
-        actions_section = {
-            margin: {left: 32}
-        }
-    }
+    pub BotLine = <ChatLine> {}
 
     pub LoadingLine = <BotLine> {
         message_section = {

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -5,11 +5,9 @@ live_design! {
     use link::widgets::*;
     use link::shaders::*;
 
-    use crate::widgets::message_thinking_block::*;
-    use crate::widgets::message_markdown::*;
+    use crate::widgets::message_content_view::*;
     use crate::widgets::message_loading::*;
     use crate::widgets::avatar::*;
-    use crate::widgets::citation_list::*;
 
 
     Sender = <View> {
@@ -115,14 +113,10 @@ live_design! {
             flow: Down,
             height: Fit,
             sender = <Sender> {}
-            text = <View> {
-                flow: Down
+            content_section = <View> {
                 height: Fit,
-                spacing: 10
                 margin: { left: 32 }
-                thinking_block = <MessageThinkingBlock> {}
-                markdown = <MessageMarkdown> {}
-                citations = <CitationList> { visible: false }
+                content = <MessageContentView> {}
             }
             editor = <Editor> { margin: { left: 32 }, visible: false }
         }
@@ -153,7 +147,7 @@ live_design! {
     pub LoadingLine = <BotLine> {
         message_section = {
             bubble = {
-                text = <View> {
+                content_section = <View> {
                     height: Fit,
                     loading = <MessageLoading> {}
                 }

--- a/moly-kit/src/widgets/message_content_view.rs
+++ b/moly-kit/src/widgets/message_content_view.rs
@@ -1,0 +1,95 @@
+use crate::protocol::*;
+use makepad_widgets::*;
+
+use super::{
+    citation_list::CitationListWidgetExt, message_thinking_block::MessageThinkingBlockWidgetExt,
+};
+
+live_design! {
+    use link::theme::*;
+    use link::widgets::*;
+
+    use crate::widgets::message_thinking_block::*;
+    use crate::widgets::message_markdown::*;
+    use crate::widgets::citation_list::*;
+
+    pub MessageContentView = {{MessageContentView}} {
+        flow: Down
+        height: Fit,
+        spacing: 10
+        thinking_block = <MessageThinkingBlock> {}
+        markdown = <MessageMarkdown> {}
+        citations = <CitationList> { visible: false }
+    }
+}
+
+#[derive(Live, Widget, LiveHook)]
+pub struct MessageContentView {
+    #[deref]
+    deref: View,
+}
+
+impl Widget for MessageContentView {
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.deref.draw_walk(cx, scope, walk)
+    }
+
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.deref.handle_event(cx, event, scope)
+    }
+}
+
+impl MessageContentView {
+    pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent) {
+        let citation_list = self.citation_list(id!(citations));
+        citation_list.borrow_mut().unwrap().urls = content.citations.clone();
+        citation_list.borrow_mut().unwrap().visible = !content.citations.is_empty();
+
+        let (thinking_block, message_body) = extract_and_remove_think_tag(&content.text);
+        self.message_thinking_block(id!(thinking_block))
+            .set_thinking_text(thinking_block);
+
+        // Workaround: Because I had to set `paragraph_spacing` to 0 in `MessageMarkdown`,
+        // we need to add a "blank" line as a workaround.
+        //
+        // Warning: If you ever read the text from this widget and not
+        // from the list, you should remove the unicode character.
+        // TODO: Remove this workaround once the markdown widget is fixed.
+        if let Some(body) = message_body {
+            self.label(id!(markdown))
+                .set_text(cx, &body.replace("\n\n", "\n\n\u{00A0}\n\n"));
+        }
+    }
+}
+
+fn extract_and_remove_think_tag(text: &str) -> (Option<String>, Option<String>) {
+    let (start_tag, end_tag) = ("<think>", "</think>");
+
+    let start_search = text.find(start_tag);
+    let end_search = text.find(end_tag);
+
+    let Some(start) = start_search else {
+        return (None, Some(text.to_string()));
+    };
+
+    let thinking_content = if let Some(end) = end_search {
+        text[start + start_tag.len()..end].trim().to_string()
+    } else {
+        text[start + start_tag.len()..].trim().to_string()
+    };
+
+    let thinking = if thinking_content.len() > 0 {
+        Some(thinking_content)
+    } else {
+        None
+    };
+
+    let body = if let Some(end) = end_search {
+        let body = text[end + end_tag.len()..].trim().to_string();
+        Some(body)
+    } else {
+        None
+    };
+
+    (thinking, body)
+}

--- a/moly-kit/src/widgets/message_loading.rs
+++ b/moly-kit/src/widgets/message_loading.rs
@@ -161,6 +161,7 @@ impl MessageLoadingRef {
         }
     }
 
+    #[allow(dead_code)]
     pub fn stop_animation(&mut self) {
         let Some(mut inner) = self.borrow_mut() else {
             return;

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -270,7 +270,8 @@ impl Messages {
 
                     let item = if message.is_writing && message.content.is_empty() {
                         let item = list.item(cx, index, live_id!(LoadingLine));
-                        item.message_loading(id!(text.loading)).animate(cx);
+                        item.message_loading(id!(content_section.loading))
+                            .animate(cx);
                         item
                     } else if let Some(_) = message
                         .content

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -256,7 +256,7 @@ impl Messages {
                     item.avatar(id!(avatar)).borrow_mut().unwrap().avatar = avatar;
                     item.label(id!(name)).set_text(cx, name);
 
-                    item.label(id!(text.label))
+                    item.label(id!(text.markdown))
                         .set_text(cx, &message.content.text);
                     self.apply_actions_and_editor_visibility(cx, &item, index);
                     item.draw_all(cx, &mut Scope::empty());

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 use makepad_widgets::*;
 
-use super::{citation::CitationAction, message_content_view::MessageContentViewWidgetRefExt};
+use super::{
+    citation::CitationAction, standard_message_content::StandardMessageContentWidgetRefExt,
+};
 
 live_design! {
     use link::theme::*;
@@ -251,7 +253,7 @@ impl Messages {
                         Some(Picture::Grapheme("y".into()));
                     item.label(id!(name)).set_text(cx, "You");
 
-                    item.message_content_view(id!(content))
+                    item.standard_message_content(id!(content))
                         .borrow_mut()
                         .unwrap()
                         .set_content(cx, &message.content);
@@ -287,7 +289,7 @@ impl Messages {
                     } else {
                         let item = list.item(cx, index, live_id!(BotLine));
 
-                        item.message_content_view(id!(content))
+                        item.standard_message_content(id!(content))
                             .borrow_mut()
                             .unwrap()
                             .set_content(cx, &message.content);

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -254,8 +254,6 @@ impl Messages {
                     item.label(id!(name)).set_text(cx, "You");
 
                     item.standard_message_content(id!(content))
-                        .borrow_mut()
-                        .unwrap()
                         .set_content(cx, &message.content);
 
                     self.apply_actions_and_editor_visibility(cx, &item, index);
@@ -290,8 +288,6 @@ impl Messages {
                         let item = list.item(cx, index, live_id!(BotLine));
 
                         item.standard_message_content(id!(content))
-                            .borrow_mut()
-                            .unwrap()
                             .set_content(cx, &message.content);
 
                         item

--- a/moly-kit/src/widgets/standard_message_content.rs
+++ b/moly-kit/src/widgets/standard_message_content.rs
@@ -13,7 +13,7 @@ live_design! {
     use crate::widgets::message_markdown::*;
     use crate::widgets::citation_list::*;
 
-    pub MessageContentView = {{MessageContentView}} {
+    pub StandardMessageContent = {{StandardMessageContent}} {
         flow: Down
         height: Fit,
         spacing: 10
@@ -24,12 +24,12 @@ live_design! {
 }
 
 #[derive(Live, Widget, LiveHook)]
-pub struct MessageContentView {
+pub struct StandardMessageContent {
     #[deref]
     deref: View,
 }
 
-impl Widget for MessageContentView {
+impl Widget for StandardMessageContent {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         self.deref.draw_walk(cx, scope, walk)
     }
@@ -39,7 +39,7 @@ impl Widget for MessageContentView {
     }
 }
 
-impl MessageContentView {
+impl StandardMessageContent {
     pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent) {
         let citation_list = self.citation_list(id!(citations));
         citation_list.borrow_mut().unwrap().urls = content.citations.clone();

--- a/moly-kit/src/widgets/standard_message_content.rs
+++ b/moly-kit/src/widgets/standard_message_content.rs
@@ -40,6 +40,7 @@ impl Widget for StandardMessageContent {
 }
 
 impl StandardMessageContent {
+    /// Set a message content to display it.
     pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent) {
         let citation_list = self.citation_list(id!(citations));
         citation_list.borrow_mut().unwrap().urls = content.citations.clone();
@@ -59,6 +60,17 @@ impl StandardMessageContent {
             self.label(id!(markdown))
                 .set_text(cx, &body.replace("\n\n", "\n\n\u{00A0}\n\n"));
         }
+    }
+}
+
+impl StandardMessageContentRef {
+    /// See [StandardMessageContent::set_content].
+    pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent) {
+        let Some(mut inner) = self.borrow_mut() else {
+            return;
+        };
+
+        inner.set_content(cx, content);
     }
 }
 


### PR DESCRIPTION
# Changes

- Take out message content from messages.rs.
- Simplify related DSLs, like chat lines DSL.
- Reuse the message content widget inside deep inquire line for now.