### PR TITLE
Fix scroll to end behavior in chat

### DIFF
--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -468,7 +468,7 @@ impl Chat {
                 let index = messages.read().messages.len() - 1;
                 let mut tasks = vec![ChatTask::UpdateMessage(index, message)];
 
-                if messages.read().is_at_bottom() {
+                if !messages.read().is_at_bottom() {
                     tasks.push(ChatTask::ScrollToBottom);
                 }
 
@@ -502,7 +502,7 @@ impl Chat {
                     })
                     .collect::<Vec<_>>();
 
-                if messages.read().is_at_bottom() {
+                if !messages.read().is_at_bottom() {
                     tasks.push(ChatTask::ScrollToBottom);
                 }
 

--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -289,9 +289,7 @@ impl WidgetMatchEvent for ChatScreen {
                         store.preferences.set_current_chat_model(chat.borrow().associated_bot.clone());
 
                         // Load messages from history into the messages widget
-                        self.messages(id!(chat.messages)).write().messages = chat.borrow().messages.clone();
-                        // TODO: This is commented out because it causes the portal list to constantly redraw
-                        // self.messages(id!(chat.messages)).write().scroll_to_bottom(cx);
+                        self.messages(id!(chat.messages)).write().set_messages(chat.borrow().messages.clone(), true);
 
                         // Set the chat's associated model in the model selector
                         if let Some(bot_id) = &chat.borrow().associated_bot {


### PR DESCRIPTION
- Updated scroll logic to trigger scrolling to the bottom only when not at the bottom of the message list.
- Introduced a deferred scroll mechanism in the Messages struct to handle scrolling after replacing the message list