### PR TITLE
Remove WasmEdge installation management

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04]
         rust: [1.81]
 
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,17 +26,11 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
         rust: [1.81]
-    env:
-      LD_LIBRARY_PATH: ~\.wasmedge\lib
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install WasmEdge
-        run: |
-          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.1
-          source $HOME/.wasmedge/env
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -67,11 +61,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install WasmEdge
-        run: |
-          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.1
-          source $HOME/.wasmedge/env
-
       - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -91,27 +80,9 @@ jobs:
     strategy:
       matrix:
         rust: [1.81]
-    env:
-      WASMEDGE_DIR: ${{ github.workspace }}\WasmEdge-0.14.1-Windows
     steps:
-      - name: Display ENV
-        run: |
-          echo $env:WASMEDGE_DIR
-
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Download WasmEdge
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri "https://github.com/WasmEdge/WasmEdge/releases/download/0.14.1/WasmEdge-0.14.1-windows.zip" -OutFile "WasmEdge-0.14.1-windows.zip"
-          Expand-Archive -LiteralPath "WasmEdge-0.14.1-windows.zip" -DestinationPath ${{ github.workspace }}
-          tree /F ${{ github.workspace }}\WasmEdge
-
-      - name: Set up Windows 10 SDK
-        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
-        with:
-          sdk-version: 20348
 
       - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,11 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         rust: [1.81]
-    env:
-      LD_LIBRARY_PATH: ~\.wasmedge\lib
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install WasmEdge
-        run: |
-          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.1
-          source $HOME/.wasmedge/env
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -59,7 +53,6 @@ jobs:
 
       - name: Build
         run: |
-          source $HOME/.wasmedge/env
           cargo packager --release --verbose
           ls dist/
 
@@ -84,11 +77,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Install WasmEdge
-        run: |
-          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.1
-          source $HOME/.wasmedge/env
 
       - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable
@@ -118,27 +106,9 @@ jobs:
     strategy:
       matrix:
         rust: [1.81]
-    env:
-      WASMEDGE_DIR: ${{ github.workspace }}\WasmEdge-0.14.1-Windows
     steps:
-      - name: Display ENV
-        run: |
-          echo $env:WASMEDGE_DIR
-
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Download WasmEdge
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri "https://github.com/WasmEdge/WasmEdge/releases/download/0.14.1/WasmEdge-0.14.1-windows.zip" -OutFile "WasmEdge-0.14.1-windows.zip"
-          Expand-Archive -LiteralPath "WasmEdge-0.14.1-windows.zip" -DestinationPath ${{ github.workspace }}
-          tree /F ${{ github.workspace }}\WasmEdge
-
-      - name: Set up Windows 10 SDK
-        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
-        with:
-          sdk-version: 20348
 
       - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,9 +107,6 @@ binaries = [
 ## (see the below `resources = [...]` block below),
 ## so we need to copy the resources to a known fixed (static) path before packaging,
 ## such that cargo-packager can locate them and include them in the final package.
-##
-## In addition, on macOS only, we must download the WasmEdge plugins in order to include them
-## in the macOS app bundle. This is because macOS apps must include all dependencies in order to pass notarization.
 before-packaging-command = """
 cargo run --manifest-path packaging/before-packaging-command/Cargo.toml before-packaging
 """
@@ -148,17 +145,9 @@ depends = "./dist/depends_deb.txt"
 desktop_template = "./packaging/moly.desktop"
 section = "utils"
 
-[package.metadata.packager.appimage]
-## `curl` is needed for `moly-runner` to auto-install wasmedge.
-bins = ["/usr/bin/curl"]
-
 [package.metadata.packager.macos]
 minimum_system_version = "11.0"
 infoPlistPath = "./packaging/Info.plist"
-frameworks = [
-    "./wasmedge/WasmEdge-0.14.1-Darwin/lib/libwasmedge.0.dylib",
-    "./wasmedge/WasmEdge-0.14.1-Darwin/plugin/libwasmedgePluginWasiNN.dylib",
-]
 
 
 ## Configuration for `cargo packager`'s generation of a macOS `.dmg`.


### PR DESCRIPTION
Remove obsolete WasmEdge installation management from CI and packaging config--now migrated to moly-server (e.g. [`build.yml`](https://github.com/moxin-org/moly-server/blob/72a9e3edeb47bca5eb7770f117055347b08bbb26/.github/workflows/build.yml)).

Subsequent changes should be made to remove references to the old WasmEdge requirements from moly-runner and build.sh.