### PR TITLE
Add error enrichment for HTTP responses in MolyKit clients

### DIFF
--- a/moly-kit/src/utils.rs
+++ b/moly-kit/src/utils.rs
@@ -6,6 +6,6 @@ pub(crate) mod portal_list;
 pub(crate) mod scraping;
 pub(crate) mod sse;
 pub(crate) mod ui_runner;
-
+pub(crate) mod errors;
 #[cfg(feature = "json")]
 pub(crate) mod serde;

--- a/moly-kit/src/utils/errors.rs
+++ b/moly-kit/src/utils/errors.rs
@@ -1,0 +1,18 @@
+use reqwest::StatusCode;
+
+pub fn enrich_http_error(status: StatusCode, original: &str) -> String {
+    let clarification = match status {
+        StatusCode::TOO_MANY_REQUESTS => "This usually means you've hit a rate limit, run out of quota/credits, or do not have access to this resource/model in your current plan.",
+        StatusCode::UNAUTHORIZED => "This usually means your API key is invalid or expired.",
+        StatusCode::FORBIDDEN => "This usually means you do not have permission to access this resource.",
+        StatusCode::BAD_REQUEST => "This was an error on our side. Please file an issue on GitHub.",
+        x if x >= StatusCode::INTERNAL_SERVER_ERROR && x <= StatusCode::HTTP_VERSION_NOT_SUPPORTED => "A server error occurred. This is likely a temporary issue with the provider.",
+        _ => "",
+    };
+
+    if clarification.is_empty() {
+        original.to_string()
+    } else {
+        format!("{original}\n\nNote: {clarification}")
+    }
+}


### PR DESCRIPTION
- Added handling error reporting for unsuccesful responses
- Introduced a new `errors` module to handle HTTP error enrichment.
- Enhanced user feedback for common error scenarios such as rate limits and unauthorized access.

Example of a message to a Gemini model when exceeding daily or minute quota:
![Screenshot 2025-04-30 at 12 54 29 PM](https://github.com/user-attachments/assets/d177b0ae-cc4c-4cd2-a662-a6de527a5a41)
