### PR TITLE
Temporarily disable agent buttons in chat history

### DIFF
--- a/moly-kit/src/widgets/prompt_input.rs
+++ b/moly-kit/src/widgets/prompt_input.rs
@@ -27,17 +27,16 @@ live_design! {
                         }
                     }
                     draw_text: {
-                        // text_style:<REGULAR_FONT>{font_size: 10},
-                        instance prompt_enabled: 1.0
-
-                        fn get_color(self) -> vec4 {
-                            return mix(#98A2B3, #000, self.prompt_enabled)
-                        }
+                        color: #000
+                        color_hover: #000
+                        color_focus: #000
+                        color_empty: #98A2B3
+                        color_empty_focus: #98A2B3
                     }
                     draw_selection: {
-                        fn pixel(self) -> vec4 {
-                            return #bbb;
-                        }
+                        color: #d9e7e9
+                        color_hover: #d9e7e9
+                        color_focus: #d9e7e9
                     }
                     draw_cursor: {
                         fn pixel(self) -> vec4 {

--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -125,24 +125,28 @@ impl Widget for ChatHistory {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let store = scope.data.get_mut::<Store>().unwrap();
-        let agents = store.chats.get_mofa_agents_list(true);
+        // let agents = store.chats.get_mofa_agents_list(true);
 
         enum Item<'a> {
             ChatsHeader,
-            AgentsHeader,
+            // AgentsHeader,
             // NoAgentsWarning(&'a str),
-            AgentButton(&'a ProviderBot),
+            // AgentButton(&'a ProviderBot),
             ChatButton(&'a ChatID),
         }
 
         let mut items: Vec<Item> = Vec::new();
 
-        if !agents.is_empty() {
-            items.push(Item::AgentsHeader);
-            for agent in &agents {
-                items.push(Item::AgentButton(agent));
-            }
-        }
+        // TODO: Temporarily disabling the agents section in the chat history.
+        // Reusing portal list items ids for different templates (e.g. a ChatsHeader becomes an AgentsHeader when agents are loaded after chats)
+        // causes drawlist issues: Drawlist id generation wrong index: 13 current gen:1 in pointer:0 / Drawlist id generation wrong 13 1 0
+
+        // if !agents.is_empty() {
+        //     items.push(Item::AgentsHeader);
+        //     for agent in &agents {
+        //         items.push(Item::AgentButton(agent));
+        //     }
+        // }
 
         items.push(Item::ChatsHeader);
 
@@ -172,15 +176,15 @@ impl Widget for ChatHistory {
                             let item = list.item(cx, item_id, live_id!(ChatsHeading));
                             item.draw_all(cx, scope);
                         }
-                        Item::AgentsHeader => {
-                            let item = list.item(cx, item_id, live_id!(AgentHeading));
-                            item.draw_all(cx, scope);
-                        }
-                        Item::AgentButton(agent) => {
-                            let item = list.item(cx, item_id, live_id!(Agent));
-                            item.as_entity_button().set_bot_id(cx, &agent.id);
-                            item.draw_all(cx, scope);
-                        }
+                        // Item::AgentsHeader => {
+                        //     let item = list.item(cx, item_id, live_id!(AgentHeading));
+                        //     item.draw_all(cx, scope);
+                        // }
+                        // Item::AgentButton(agent) => {
+                        //     let item = list.item(cx, item_id, live_id!(Agent));
+                        //     item.as_entity_button().set_bot_id(cx, &agent.id);
+                        //     item.draw_all(cx, scope);
+                        // }
                         Item::ChatButton(chat_id) => {
                             let mut item = list
                                 .item(cx, item_id, live_id!(ChatHistoryCard))


### PR DESCRIPTION
Reusing portal list items ids for different templates (e.g. a ChatsHeader becomes an AgentsHeader when agents are loaded after chats).
This causes DrawList issues e.g.: `Drawlist id generation wrong index: 13 current gen:1 in pointer:0` and `Drawlist id generation wrong 13 1 0` this seems like a bug in PortalList. Disabling this feature until we have a solution
