### PR TITLE
Disable prompt while repo loading

### DIFF
--- a/moly-kit/src/widgets/message_loading.rs
+++ b/moly-kit/src/widgets/message_loading.rs
@@ -39,6 +39,7 @@ live_design! {
 
         flow: Down,
         spacing: 4,
+        padding: {right: 100}
 
         line1 = <Bar> {}
         line2 = <Bar> {}

--- a/moly-kit/src/widgets/prompt_input.rs
+++ b/moly-kit/src/widgets/prompt_input.rs
@@ -56,13 +56,21 @@ live_design! {
                         }
 
                         draw_bg: {
+                            fn get_color(self) -> vec4 {
+                                if self.enabled == 0.0 {
+                                    return #D0D5DD;
+                                }
+
+                                return #000;
+                            }
+
                             fn pixel(self) -> vec4 {
                                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                                 let center = self.rect_size * 0.5;
                                 let radius = min(self.rect_size.x, self.rect_size.y) * 0.5;
 
                                 sdf.circle(center.x, center.y, radius);
-                                sdf.fill_keep(#000);
+                                sdf.fill_keep(self.get_color());
 
                                 return sdf.result
                             }
@@ -159,9 +167,19 @@ impl Widget for PromptInput {
 
         match self.interactivity {
             Interactivity::Enabled => {
+                button.apply_over(cx, live! {
+                    draw_bg: {
+                        enabled: 1.0
+                    }
+                });
                 button.set_enabled(cx, true);
             }
             Interactivity::Disabled => {
+                button.apply_over(cx, live! {
+                    draw_bg: {
+                        enabled: 0.0
+                    }
+                });
                 button.set_enabled(cx, false);
             }
         }

--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -131,7 +131,7 @@ live_design! {
     }
 }
 
-#[derive(Live, LiveHook, Widget)]
+#[derive(Live, Widget)]
 pub struct ChatScreen {
     #[deref]
     view: View,
@@ -144,6 +144,12 @@ pub struct ChatScreen {
 
     #[rust]
     creating_bot_repo: bool,
+}
+
+impl LiveHook for ChatScreen {
+    fn after_new_from_doc(&mut self, _cx:&mut Cx) {
+        self.prompt_input(id!(chat.prompt)).write().disable();
+    }
 }
 
 impl Widget for ChatScreen {
@@ -164,6 +170,7 @@ impl Widget for ChatScreen {
 
         if self.should_load_repo_to_store {
             store.bot_repo = self.chat(id!(chat)).read().bot_repo.clone();
+            self.prompt_input(id!(chat.prompt)).write().enable();
             self.should_load_repo_to_store = false;
         } else if (self.first_render || should_recreate_bot_repo) && !self.creating_bot_repo {
             self.create_bot_repo(cx, scope);

--- a/src/chat/model_selector_loading.rs
+++ b/src/chat/model_selector_loading.rs
@@ -9,7 +9,7 @@ live_design! {
     use crate::shared::widgets::*;
     use crate::landing::model_card::ModelCard;
 
-    ANIMATION_SPEED = 1.5;
+    ANIMATION_SPEED = 1.2;
 
     Bar = <RoundedView> {
         width: Fill,
@@ -22,7 +22,7 @@ live_design! {
             fn get_color(self) -> vec4 {
                 return mix(
                     #F3FFA2,
-                    #E3FBFF,
+                    #B0CBC6,
                     self.pos.x + self.dither
                 )
             }


### PR DESCRIPTION
Disable the submit button of PromptInput while the repo is still loading. 
This prevents sending a message while the selected bot hasn't been loading into the repo yet.