### PR TITLE
Enhance MessageMarkdown code with styling and copy functionality

### DIFF
--- a/moly-kit/src/widgets/message_markdown.rs
+++ b/moly-kit/src/widgets/message_markdown.rs
@@ -15,14 +15,72 @@ live_design! {
         width: Fill, height: Fit,
         font_size: 10.0,
         code_block = <View> {
-            width:Fill,
-            height:Fit,
+            margin: {top: -5}
+            width: 900,
+            height: Fit,
+            flow: Down
+            <RoundedView>{
+                draw_bg: {
+                    border_radius: 0.0
+                    border_size: 1.2
+                    border_color: #1d2330
+                }
+                width:Fill,
+                height:Fit,
+                align:{ x: 1.0 }
+                
+                copy_code_button = <ButtonFlat> {
+                    margin:{right: 2}
+                    draw_bg: {
+                        border_size: 0.0
+                    }
+                    icon_walk: {
+                        width: 12, height: Fit,
+                        margin: { left: 10 }
+                    }
+                    draw_icon: {
+                        color: #x0
+                        color_hover: #3c3c3c
+                        color_down: #x0
+                        color_focus: #x0
+                        svg_file: dep("crate://self/resources/copy.svg"),
+                    }
+                }
+            }
             code_view = <CodeView>{
                 editor: {
+                    margin: {top: -2}
                     pad_left_top: vec2(10.0,10.0)
-                    width: Fill,
+                    width: 900,
                     height: Fit,
-                    draw_bg: { color: #3c3c3c },
+                    draw_bg: { color: #1d2330 },
+                    draw_text: {
+                        text_style: {
+                            font_size: 10,
+                        }
+                    }
+
+                    // Inspired by Electron Highlighter theme https://electron-highlighter.github.io
+                    token_colors: {
+                        whitespace: #a8b5d1,        // General text/punctuation color as fallback
+                        delimiter: #a8b5d1,          // punctuation
+                        delimiter_highlight: #c5cee0, // Using a slightly brighter gray for highlight
+                        error_decoration: #f44747,   // token.error-token
+                        warning_decoration: #cd9731, // token.warn-token
+                        
+                        unknown: #a8b5d1,          // General text color
+                        branch_keyword: #d2a6ef,     // keyword.control
+                        constant: #ffd9af,         // constant.numeric
+                        identifier: #a8b5d1,         // variable
+                        loop_keyword: #d2a6ef,       // keyword.control.loop
+                        number: #ffd9af,           // constant.numeric
+                        other_keyword: #d2a6ef,      // keyword
+                        punctuator: #a8b5d1,         // punctuation
+                        string: #58ffc7,           // string
+                        function: #82aaff,         // entity.name.function
+                        typename: #fcf9c3,         // entity.name.class/type
+                        comment: #506686,          // comment
+                    }
                 }
             }
         }

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -11,6 +11,7 @@ use crate::{
         message_thinking_block::MessageThinkingBlockWidgetRefExt,
     },
 };
+use makepad_code_editor::code_view::CodeViewWidgetRefExt;
 use makepad_widgets::*;
 
 use super::{citation::CitationAction, citation_list::CitationListWidgetRefExt};
@@ -460,6 +461,17 @@ impl Messages {
 
             if let Some(change) = item.text_input(id!(input)).changed(actions) {
                 self.current_editor.as_mut().unwrap().buffer = change;
+            }
+        }
+
+        // Handle code copy
+        // Since the Markdown widget could have multiple code blocks, we need the widget that triggered the action
+        if let Some(wa) = event.actions().widget_action(id!(copy_code_button)){
+            if wa.widget().as_button().pressed(event.actions()){
+                // nth(2) refers to the code view in the MessageMarkdown widget
+                let code_view = wa.widget_nth(2).widget(id!(code_view));
+                let text_to_copy = code_view.as_code_view().text();
+                cx.copy_to_clipboard(&text_to_copy);
             }
         }
 


### PR DESCRIPTION
### Changes
- Updated layout and styling for code blocks, including margins and background colors.
- Added a button to copy code from the code view to the clipboard, handling multiple code blocks within the Markdown widget.

![image](https://github.com/user-attachments/assets/77a32fa7-b0f0-4149-90fe-fe95320f2f9d)
