### PR TITLE
Add MolyKit theming to fix some issues kit-wide

### DIFF
--- a/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_content.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_content.rs
@@ -6,6 +6,7 @@ use makepad_widgets::*;
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
     use link::shaders::*;
 
     use crate::clients::deep_inquire::widgets::stages::*;

--- a/moly-kit/src/clients/deep_inquire/widgets/stages.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/stages.rs
@@ -7,8 +7,9 @@ use crate::deep_inquire::{Stage, StageType, SubStage};
 
 live_design! {
     use link::theme::*;
-    use link::shaders::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
+    use link::shaders::*;
 
     use makepad_code_editor::code_view::CodeView;
     use crate::widgets::citation_list::*;
@@ -119,6 +120,7 @@ live_design! {
         flow: Down
         spacing: 10
         content_heading_label = <Label> {
+            padding: 0
             width: Fill
             draw_text: {
                 wrap: Word

--- a/moly-kit/src/clients/deep_inquire/widgets/stages.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/stages.rs
@@ -120,7 +120,6 @@ live_design! {
         flow: Down
         spacing: 10
         content_heading_label = <Label> {
-            padding: 0
             width: Fill
             draw_text: {
                 wrap: Word

--- a/moly-kit/src/widgets.rs
+++ b/moly-kit/src/widgets.rs
@@ -11,8 +11,10 @@ mod message_markdown;
 mod message_thinking_block;
 mod slot;
 mod standard_message_content;
+mod theme_moly_kit_light;
 
 pub mod messages;
+use makepad_widgets::*;
 pub use messages::*;
 
 pub mod prompt_input;
@@ -26,6 +28,11 @@ cfg_if::cfg_if! {
 }
 
 pub fn live_design(cx: &mut makepad_widgets::Cx) {
+    theme_moly_kit_light::live_design(cx);
+    // Link the MolyKit theme to the MolyKit-specific theme.
+    // Currently we only have a light theme which we use as default.
+    cx.link(live_id!(moly_kit_theme), live_id!(theme_moly_kit_light));
+
     citation::live_design(cx);
     citation_list::live_design(cx);
     makepad_code_editor::live_design(cx);

--- a/moly-kit/src/widgets/avatar.rs
+++ b/moly-kit/src/widgets/avatar.rs
@@ -5,8 +5,9 @@ use makepad_widgets::*;
 
 live_design! {
     use link::theme::*;
-    use link::shaders::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
+    use link::shaders::*;
 
     pub Avatar = {{Avatar}} <View> {
         height: Fit,

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -9,8 +9,9 @@ use crate::*;
 
 live_design!(
     use link::theme::*;
-    use link::shaders::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
+    use link::shaders::*;
 
     use crate::widgets::messages::*;
     use crate::widgets::prompt_input::*;

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -3,6 +3,7 @@ use makepad_widgets::*;
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
     use link::shaders::*;
 
     use crate::widgets::standard_message_content::*;

--- a/moly-kit/src/widgets/citation.rs
+++ b/moly-kit/src/widgets/citation.rs
@@ -6,7 +6,7 @@ use url::Url;
 live_design! {
     use link::theme::*;
     use link::widgets::*;
-
+    use link::moly_kit_theme::*;
 
     pub Citation = {{Citation}} <RoundedView> {
         flow: Down,
@@ -14,7 +14,7 @@ live_design! {
         cursor: Hand,
         width: 170,
         padding: 6,
-        spacing: 4,
+        spacing: 5,
         draw_bg: {
             color: #f2f2f2
             border_radius: 3

--- a/moly-kit/src/widgets/citation_list.rs
+++ b/moly-kit/src/widgets/citation_list.rs
@@ -5,6 +5,7 @@ use super::citation::CitationWidgetRefExt;
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
 
     use crate::widgets::citation::*;
 
@@ -15,7 +16,7 @@ live_design! {
             flow: Right,
             width: Fill,
             // Fit doesn't work here.
-            height: 48,
+            height: 50,
             Citation = <Citation> {
                 // spacing on parent doesn't work
                 margin: {right: 8},

--- a/moly-kit/src/widgets/message_loading.rs
+++ b/moly-kit/src/widgets/message_loading.rs
@@ -2,8 +2,9 @@ use makepad_widgets::*;
 
 live_design! {
     use link::theme::*;
-    use link::shaders::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
+    use link::shaders::*;
 
     ANIMATION_SPEED = 0.33
 

--- a/moly-kit/src/widgets/message_markdown.rs
+++ b/moly-kit/src/widgets/message_markdown.rs
@@ -3,6 +3,7 @@ use makepad_widgets::*;
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
     // import crate::shared::styles::*;
 
     use makepad_code_editor::code_view::CodeView;

--- a/moly-kit/src/widgets/message_thinking_block.rs
+++ b/moly-kit/src/widgets/message_thinking_block.rs
@@ -3,6 +3,7 @@ use makepad_widgets::*;
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
     use crate::widgets::message_markdown::MessageMarkdown;
 
     ICON_COLLAPSE = dep("crate://self/resources/icons/collapse.svg")

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -19,6 +19,7 @@ use super::{
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
     use link::shaders::*;
 
     use crate::widgets::chat_lines::*;

--- a/moly-kit/src/widgets/prompt_input.rs
+++ b/moly-kit/src/widgets/prompt_input.rs
@@ -4,6 +4,7 @@ use std::cell::{Ref, RefMut};
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
     use link::shaders::*;
 
     pub PromptInput = {{PromptInput}} <CommandTextInput> {

--- a/moly-kit/src/widgets/slot.rs
+++ b/moly-kit/src/widgets/slot.rs
@@ -3,6 +3,7 @@ use makepad_widgets::*;
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
 
     pub Slot = {{Slot}} {}
 }

--- a/moly-kit/src/widgets/standard_message_content.rs
+++ b/moly-kit/src/widgets/standard_message_content.rs
@@ -8,6 +8,7 @@ use super::{
 live_design! {
     use link::theme::*;
     use link::widgets::*;
+    use link::moly_kit_theme::*;
 
     use crate::widgets::message_thinking_block::*;
     use crate::widgets::message_markdown::*;

--- a/moly-kit/src/widgets/theme_moly_kit_light.rs
+++ b/moly-kit/src/widgets/theme_moly_kit_light.rs
@@ -1,0 +1,26 @@
+use makepad_widgets::*;
+
+live_design! {
+    // The default theme for MolyKit. 
+    // 
+    // Instead of overriding Makepad's default theme (under link::theme::*),
+    // we create a MolyKit-specific theme (under link::widgets::*).
+    // 
+    // This way, we can keep Makepad's default theme as is, to not interfer with the rest of the application 
+    // (and because there's no easy way to override Makepad's default theme without copy-pasting the entire theme, which would quickly become deprecated).
+    // 
+    // MolyKit's theme is applied via the `cx.link(live_id!(moly_kit_theme), live_id!(<some_theme>));`
+    // line in the `live_design` macro in `src/widgets.rs`.
+    link theme_moly_kit_light;
+
+    use link::theme::*;
+    use link::widgets::*;
+    
+    // TODO: In this file we'll set a set of rules/constants that will be used to style MolyKit's widgets.
+    // We can also here override Makepad's default theme as needed (e.g. THEME_SPACE_FACTOR).
+    //
+    // Currently we're using this to globally (MolyKit-wide) override some painful defaults in Makepad.
+    // Ideally we'd override some spacing values in Makepad, but that doesn't seem to be enough, 
+    // therefore we're also overriding some widget-specific values here.
+    pub Label = <Label> { padding: 0 }
+}


### PR DESCRIPTION
### Changes

Latest Makepad includes some added spacing and padding to widgets that becomes very painful to override manually everywhere. 
Therefore we're introducing a MolyKit-specific theme that we can start using to override those values or create our own.
We're not overriding the linked Makepad theme as that has consequences for the entire application, not just the kit.

For more details check out the comments in the theme file.