### PR TITLE
Enhance ModelSelector by displaying assistant availability

### DIFF
--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -115,7 +115,7 @@ live_design! {
                 width: Fit
                 height: Fill
                 align: {y: 0.5}
-                padding: {left: 4, top: 6}
+                padding: {left: 4, top: 10}
 
                 avatar_section = <View> {
                     width: Fit, height: Fill,
@@ -125,11 +125,11 @@ live_design! {
             }
             <View> {
                 width: Fill
-                height: Fit
+                height: Fill
                 flow: Down
                 align: {y: 0.5, x: 0.0}
                 spacing: 3
-                padding: { left: 6, top: 6, bottom: 6 }
+                padding: { left: 6, top: 10, bottom: 6 }
 
                 model_or_agent_name_label = <Label> {
                     width: Fit,
@@ -143,15 +143,17 @@ live_design! {
 
                 <View> {
                     width: Fill
-                    height: Fit
+                    height: Fill
                     flow: Right
                     spacing: 5
                     padding: { top: 2, bottom: 2 }
+                    align: {y: 0.5}
 
                     <View> {
                         width: Fill,
-                        height: Fit,
+                        height: Fill,
                         flow: Down,
+                        align: {y: 0.5}
 
                         title_input_container = <View> {
                             visible: false,

--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -214,7 +214,7 @@ impl Widget for ModelSelector {
             event.hits_with_capture_overload(cx, self.view(id!(button)).area(), true)
         {
             let is_syncing = matches!(store.provider_syncing_status, ProviderSyncingStatus::Syncing(_));
-            if fd.tap_count == 1 && !store.chats.available_bots.is_empty() && !is_syncing {
+            if fd.tap_count == 1 && !store.chats.get_all_bots(true).is_empty() && !is_syncing {
                 self.open = !self.open;
 
                 if self.open {
@@ -303,8 +303,6 @@ impl Widget for ModelSelector {
         if self.currently_selected_model.is_none() {
             self.view(id!(choose)).set_visible(cx, true);
             self.view(id!(selected_bot)).set_visible(cx, false);
-            self.view(id!(icon_drop)).set_visible(cx, true);
-            choose_label.set_text(cx, "Choose your AI assistant");
             let color = vec3(0.0, 0.0, 0.0);
             choose_label.apply_over(
                 cx,
@@ -314,6 +312,15 @@ impl Widget for ModelSelector {
                     }
                 },
             );
+
+            // If there are available bots, prompt the user to choose an assistant
+            if !store.chats.get_all_bots(true).is_empty() {  
+                choose_label.set_text(cx, "Choose your AI assistant");
+                self.view(id!(icon_drop)).set_visible(cx, true);
+            } else {
+                choose_label.set_text(cx, "No assistants available, check your provider settings");
+                self.view(id!(icon_drop)).set_visible(cx, false);
+            }
         } else if let ProviderSyncingStatus::Syncing(_syncing) = &store.provider_syncing_status {
             self.view(id!(choose)).set_visible(cx, true);
             self.view(id!(icon_drop)).set_visible(cx, false);


### PR DESCRIPTION
### Changes

- Model selector now shows "No assistants available, check your provider settings" instead of "Choose your assistant" if there are no bots available.
- Unrelated, small UI fixes on chat history