### PR TITLE
Introduce smooth typing for streaming messages

### DIFF
--- a/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_content.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_content.rs
@@ -13,7 +13,7 @@ live_design! {
     use crate::widgets::message_markdown::*;
 
     pub DeepInquireContent = {{DeepInquireContent}} {
-        flow: Down,
+        flow: Down, spacing: 10
         height: Fit,
         <Label> {
             text: "Steps"

--- a/moly-kit/src/clients/deep_inquire/widgets/stages.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/stages.rs
@@ -154,11 +154,11 @@ live_design! {
                 padding: 10
 
                 stage_toggle = <CustomRoundedShadowView> {
-                    width: 40, height: 40
+                    width: 45, height: 45
                     padding: 4
                     draw_bg: {
                         color: #f9f9f9,
-                        border_radius: 10.0,
+                        border_radius: 11.0,
                         uniform shadow_color: #0001
                         shadow_radius: 8.0,
                         shadow_offset: vec2(0.0,-2.0)
@@ -170,14 +170,14 @@ live_design! {
                     stage_bubble_text = <Label> {
                         text: "1"
                         draw_text: {
-                            text_style: <THEME_FONT_BOLD>{font_size: 10},
+                            text_style: <THEME_FONT_BOLD>{font_size: 14},
                             color: #000
                         }
                     }
                 }
                 stage_title = <Label> {
                     draw_text: {
-                        text_style: <THEME_FONT_BOLD>{font_size: 10},
+                        text_style: <THEME_FONT_BOLD>{font_size: 11},
                         color: #000
                     }
                 }
@@ -191,7 +191,7 @@ live_design! {
                     width: Fill
                     draw_text: {
                         wrap: Word
-                        text_style: {font_size: 10},
+                        text_style: {font_size: 11},
                         color: #x0
                     }
                 }

--- a/moly-kit/src/widgets/avatar.rs
+++ b/moly-kit/src/widgets/avatar.rs
@@ -29,7 +29,7 @@ live_design! {
                 width: Fit,
                 height: Fit,
                 draw_text:{
-                    text_style: <THEME_FONT_BOLD>{font_size: 8},
+                    text_style: <THEME_FONT_BOLD>{font_size: 8.5},
                     color: #fff,
                 }
                 text: "P"

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -20,7 +20,7 @@ live_design! {
         name = <Label> {
             padding: 0
             draw_text:{
-                text_style: <THEME_FONT_BOLD>{font_size: 10},
+                text_style: <THEME_FONT_BOLD>{font_size: 11},
                 color: #000
             }
         }

--- a/moly-kit/src/widgets/citation.rs
+++ b/moly-kit/src/widgets/citation.rs
@@ -31,7 +31,7 @@ live_design! {
 
             site = <Label> {
                 draw_text: {
-                    text_style: <THEME_FONT_BOLD>{font_size: 8.5},
+                    text_style: <THEME_FONT_BOLD>{font_size: 9},
                     color: #555,
                 }
             }
@@ -39,7 +39,7 @@ live_design! {
 
         title = <Label> {
             draw_text: {
-                text_style: {font_size: 8},
+                text_style: {font_size: 9},
                 color: #000,
             }
         }

--- a/moly-kit/src/widgets/message_markdown.rs
+++ b/moly-kit/src/widgets/message_markdown.rs
@@ -4,20 +4,23 @@ live_design! {
     use link::theme::*;
     use link::widgets::*;
     use link::moly_kit_theme::*;
-    // import crate::shared::styles::*;
 
     use makepad_code_editor::code_view::CodeView;
 
-    // copied as it is from moly
-    MessageText = <Markdown> {
+    MD_LINE_SPACING = 1.5
+    MD_FONT_COLOR = #000
+
+    pub MessageMarkdown = <Markdown> {
         padding: 0,
-        paragraph_spacing: 20.0,
+        margin: 0,
+        paragraph_spacing: 16,
+        heading_base_scale: 1.6
+
         font_color: #000,
         width: Fill, height: Fit,
-        font_size: 10.0,
+        font_size: 11.0,
         code_block = <View> {
-            margin: {top: -5}
-            width: 900,
+            width: Fill,
             height: Fit,
             flow: Down
             <RoundedView>{
@@ -50,9 +53,9 @@ live_design! {
             }
             code_view = <CodeView>{
                 editor: {
-                    margin: {top: -2}
+                    margin: {top: -2, bottom: 2}
                     pad_left_top: vec2(10.0,10.0)
-                    width: 900,
+                    width: Fill,
                     height: Fit,
                     draw_bg: { color: #1d2330 },
                     draw_text: {
@@ -99,35 +102,39 @@ live_design! {
                 color_hover: #0f0,
             }
         }
-    }
 
-    BaseMarkdown = <MessageText> {
-        padding: 0,
-        margin: 0,
-        // TODO: Fix this empty space issue in Makepad. First paragraph should not have a top margin.
-        // Workaround: This property causes an unintended initial space so let's disable it.
-        paragraph_spacing: 16,
-        heading_base_scale: 1.6
-    }
-
-    pub MessageMarkdown = <BaseMarkdown> {
         draw_normal: {
-            color: (#000),
+            color: (MD_FONT_COLOR),
+            text_style: {
+                line_spacing: (MD_LINE_SPACING)
+            }
         }
         draw_italic: {
-            color: (#000),
+            color: (MD_FONT_COLOR),
+            text_style: {
+                line_spacing: (MD_LINE_SPACING)
+            }
         }
         draw_bold: {
-            color: (#000),
+            color: (MD_FONT_COLOR),
+            text_style: {
+                line_spacing: (MD_LINE_SPACING)
+            }
         }
         draw_bold_italic: {
-            color: (#000),
+            color: (MD_FONT_COLOR),
+            text_style: {
+                line_spacing: (MD_LINE_SPACING)
+            }
         }
         draw_fixed: {
-            color: (#000),
+            color: (MD_FONT_COLOR),
+            text_style: {
+                line_spacing: (MD_LINE_SPACING)
+            }
         }
         draw_block: {
-            line_color: (#000)
+            line_color: (MD_FONT_COLOR)
             sep_color: (#EDEDED)
             quote_bg_color: (#EDEDED)
             quote_fg_color: (#969696)

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -27,12 +27,14 @@ live_design! {
 
     pub Messages = {{Messages}} {
         flow: Overlay,
+        padding: { left: 15, right: 15 }
 
         // TODO: Consider moving this out to it's own crate now that custom content
         // is supported.
         deep_inquire_content: <DeepInquireContent> {}
 
         list = <PortalList> {
+            padding: { left: 10, right: 80 }
             scroll_bar: {
                 bar_size: 0.0,
             }
@@ -56,7 +58,7 @@ live_design! {
                 padding: {bottom: 2},
                 icon_walk: {
                     width: 12, height: 12
-                    margin: {left: 4.5},
+                    margin: {left: 4.5, top: 2.5},
                 }
                 draw_icon: {
                     svg_file: dep("crate://self/resources/jump_to_bottom.svg")
@@ -306,7 +308,7 @@ impl Messages {
                     item.slot(id!(content))
                         .current()
                         .as_standard_message_content()
-                        .set_content(cx, &message.content);
+                        .set_content(cx, &message.content, false);
 
                     self.apply_actions_and_editor_visibility(cx, &item, index);
                     item.draw_all(cx, &mut Scope::empty());

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -52,13 +52,12 @@ live_design! {
         <View> {
             align: {x: 1.0, y: 1.0},
             jump_to_bottom = <Button> {
-                width: 34,
-                height: 34,
-                margin: 2,
-                padding: {bottom: 2},
+                width: 36,
+                height: 36,
+                margin: {left: 2, right: 2, top: 2, bottom: 10},
                 icon_walk: {
-                    width: 12, height: 12
-                    margin: {left: 4.5, top: 2.5},
+                    width: 16, height: 16
+                    margin: {left: 4.5, top: 6.5},
                 }
                 draw_icon: {
                     svg_file: dep("crate://self/resources/jump_to_bottom.svg")
@@ -73,7 +72,7 @@ live_design! {
 
                         sdf.circle(center.x, center.y, radius - 1.0);
                         sdf.fill_keep(#fff);
-                        sdf.stroke(#EAECF0, 1.0);
+                        sdf.stroke(#EAECF0, 1.5);
 
                         return sdf.result
                     }

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -275,7 +275,7 @@ impl Messages {
                             item.slot(id!(content))
                                 .current()
                                 .as_standard_message_content()
-                                .set_content(cx, &error_content);
+                                .set_content(cx, &error_content, false);
                             
                             self.apply_actions_and_editor_visibility(cx, &item, index);
                             item.draw_all(cx, &mut Scope::empty());
@@ -291,7 +291,7 @@ impl Messages {
                     item.slot(id!(content))
                         .current()
                         .as_standard_message_content()
-                        .set_content(cx, &message.content);
+                        .set_content(cx, &message.content, false);
                     
                     self.apply_actions_and_editor_visibility(cx, &item, index);
                     item.draw_all(cx, &mut Scope::empty());
@@ -345,7 +345,7 @@ impl Messages {
                         slot.restore();
                         slot.default()
                             .as_standard_message_content()
-                            .set_content(cx, &message.content);
+                            .set_content(cx, &message.content, message.is_writing);
                     }
 
                     self.apply_actions_and_editor_visibility(cx, &item, index);

--- a/moly-kit/src/widgets/prompt_input.rs
+++ b/moly-kit/src/widgets/prompt_input.rs
@@ -21,7 +21,7 @@ live_design! {
             }
             center = {
                 text_input = {
-                    empty_text: "Start typing",
+                    empty_text: "Start typing...",
                     draw_bg: {
                         fn pixel(self) -> vec4 {
                             return vec4(0.);
@@ -33,6 +33,7 @@ live_design! {
                         color_focus: #000
                         color_empty: #98A2B3
                         color_empty_focus: #98A2B3
+                        text_style: {font_size: 11}
                     }
                     draw_selection: {
                         color: #d9e7e9

--- a/moly-kit/src/widgets/standard_message_content.rs
+++ b/moly-kit/src/widgets/standard_message_content.rs
@@ -28,7 +28,25 @@ live_design! {
 pub struct StandardMessageContent {
     #[deref]
     deref: View,
+
+    #[rust]
+    smooth_typing: SmoothTyping,
 }
+
+/// The state of the virtual typing animation.
+///
+/// Used to simulate someone typing the message.
+#[derive(Default)]
+struct SmoothTyping {
+    pub target_text: String,
+    pub current_char_len: usize,
+    pub typing_speed_chars_sec: usize,
+    pub last_update: f64,
+    pub next_frame: NextFrame,
+}
+
+const DEFAULT_TYPING_SPEED_CHARS_SEC: usize = 300;
+const TYPING_ANIMATION_CHAR: &str = "●";
 
 impl Widget for StandardMessageContent {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
@@ -36,13 +54,24 @@ impl Widget for StandardMessageContent {
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        self.deref.handle_event(cx, event, scope)
+        match event {
+            Event::NextFrame(frame_event) => {
+                if frame_event.set.contains(&self.smooth_typing.next_frame) {
+                    if !self.smooth_typing.target_text.is_empty() &&
+                       self.smooth_typing.current_char_len < self.smooth_typing.target_text.chars().count() {
+                        self.animate_typing(cx, frame_event.time);
+                    }
+                }
+            }
+            _ => ()
+        }
+        self.deref.handle_event(cx, event, scope);
     }
 }
 
 impl StandardMessageContent {
     /// Set a message content to display it.
-    pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent) {
+    pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent, is_writing: bool) {
         let citation_list = self.citation_list(id!(citations));
         citation_list.borrow_mut().unwrap().urls = content.citations.clone();
         citation_list.borrow_mut().unwrap().visible = !content.citations.is_empty();
@@ -51,26 +80,107 @@ impl StandardMessageContent {
         self.message_thinking_block(id!(thinking_block))
             .set_thinking_text(thinking_block);
 
-        // Workaround: Because I had to set `paragraph_spacing` to 0 in `MessageMarkdown`,
-        // we need to add a "blank" line as a workaround.
-        //
-        // Warning: If you ever read the text from this widget and not
-        // from the list, you should remove the unicode character.
-        // TODO: Remove this workaround once the markdown widget is fixed.
         if let Some(body) = message_body {
-            self.label(id!(markdown)).set_text(cx, &body);
+            if is_writing {
+                self.smooth_typing.target_text = body;
+
+                if self.smooth_typing.typing_speed_chars_sec == 0 {
+                    self.smooth_typing.typing_speed_chars_sec = DEFAULT_TYPING_SPEED_CHARS_SEC;
+                }
+
+                if self.smooth_typing.current_char_len < self.smooth_typing.target_text.chars().count() {
+                    self.smooth_typing.next_frame = cx.new_next_frame();
+                }
+            } else {
+                // For non-writing messages, check if we're in the middle of typing animation
+                let body_chars = body.chars().count();
+                let currently_showing = if self.smooth_typing.target_text == body {
+                    // If target text is already this message, use current_char_len
+                    self.smooth_typing.current_char_len
+                } else {
+                    // Otherwise show it completely
+                    body_chars
+                };
+                
+                // If we're in the middle of typing this exact message, continue animation
+                if self.smooth_typing.target_text == body && currently_showing < body_chars {
+                    // Keep the animation going to completion
+                    self.smooth_typing.next_frame = cx.new_next_frame();
+                } else {
+                    // Either a different message or already showing completely, 
+                    // so display it immediately
+                    self.label(id!(markdown)).set_text(cx, &body);
+                    self.smooth_typing.target_text = body.clone();
+                    self.smooth_typing.current_char_len = body_chars;
+                    self.smooth_typing.last_update = 0.0;
+                }
+            }
+        } else {
+            self.label(id!(markdown)).set_text(cx, "");
+            self.smooth_typing.target_text.clear();
+            self.smooth_typing.current_char_len = 0;
+            self.smooth_typing.last_update = 0.0;
+        }
+    }
+
+    fn animate_typing(&mut self, cx: &mut Cx, time: f64) {
+        if self.smooth_typing.target_text.is_empty() || self.smooth_typing.typing_speed_chars_sec == 0 {
+            return;
+        }
+
+        // If we've already shown the entire message, don't animate
+        let target_char_count = self.smooth_typing.target_text.chars().count();
+        if self.smooth_typing.current_char_len >= target_char_count {
+            return;
+        }
+
+        let current_frame_time = time;
+        if self.smooth_typing.last_update == 0.0 {
+            self.smooth_typing.last_update = current_frame_time;
+        }
+
+        let time_delta = current_frame_time - self.smooth_typing.last_update;
+        
+        if time_delta <= 0.0 && self.smooth_typing.current_char_len < target_char_count {
+            self.smooth_typing.next_frame = cx.new_next_frame();
+            return;
+        }
+
+        // Calculate how many characters to reveal based on time delta
+        let chars_to_reveal_float = time_delta * self.smooth_typing.typing_speed_chars_sec as f64;
+
+        if chars_to_reveal_float >= 1.0 {
+            let num_chars_to_add = chars_to_reveal_float.floor() as usize;
+            
+            let new_len = self.smooth_typing.current_char_len + num_chars_to_add;
+            self.smooth_typing.current_char_len = new_len.min(target_char_count);
+
+            let mut display_text = self.smooth_typing.target_text
+                .chars()
+                .take(self.smooth_typing.current_char_len)
+                .collect::<String>();
+
+            // Add a character at the end to simulate typing
+            display_text.push_str(format!(" {}", TYPING_ANIMATION_CHAR).as_str());
+            
+            self.label(id!(markdown)).set_text(cx, &display_text);
+            self.smooth_typing.last_update = current_frame_time;
+        }
+
+        if self.smooth_typing.current_char_len < target_char_count {
+            self.smooth_typing.next_frame = cx.new_next_frame();
         }
     }
 }
 
 impl StandardMessageContentRef {
     /// See [StandardMessageContent::set_content].
-    pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent) {
+    pub fn set_content(&mut self, cx: &mut Cx, content: &MessageContent, is_writing: bool) {
         let Some(mut inner) = self.borrow_mut() else {
             return;
         };
 
-        inner.set_content(cx, content);
+        inner.set_content(cx, content, is_writing);
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -112,7 +112,7 @@ live_design! {
                             shadow_offset: vec2(0.0,-1.5)
                         }
 
-                        margin: {top: 7, right: 7, bottom: 7}
+                        margin: {top: 12, right: 12, bottom: 12}
                         padding: 3
 
                         flow: Overlay,

--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -61,7 +61,7 @@ live_design! {
                     height: Fill,
 
                     margin: { top: 120 }
-                    padding: { left: 10, right: 10, bottom: 30 }
+                    padding: { left: 10, right: 10, bottom: 20 }
 
                     list = <PortalList> {
                         drag_scrolling: false,

--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -22,7 +22,7 @@ live_design! {
     HeadingLabel = <Label> {
         margin: {left: 4, bottom: 4},
         draw_text:{
-            text_style: <BOLD_FONT>{font_size: 10},
+            text_style: <BOLD_FONT>{font_size: 10.5},
             color: #3
         }
     }
@@ -61,7 +61,7 @@ live_design! {
                     height: Fill,
 
                     margin: { top: 120 }
-                    padding: { left: 14, right: 14, bottom: 58 }
+                    padding: { left: 10, right: 10, bottom: 30 }
 
                     list = <PortalList> {
                         drag_scrolling: false,
@@ -72,7 +72,6 @@ live_design! {
                         }
                         ChatsHeading = <HeadingLabel> { text: "CHATS", margin: {top: 10}, }
                         ChatHistoryCard = <ChatHistoryCard> {
-                            padding: {top: 4}
                             cursor: Default
                         }
                     }

--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -77,12 +77,12 @@ live_design! {
     pub ChatHistoryCard = {{ChatHistoryCard}} {
         flow: Overlay,
         width: Fill,
-        height: 60,
+        height: 56,
 
         selected_bg = <RoundedInnerShadowView> {
             width: Fill
             height: Fill
-            padding: {left: 4, right: 4}
+            padding: {left: 8, right: 8}
 
             show_bg: true
 
@@ -99,8 +99,8 @@ live_design! {
             width: Fill
             height: Fill
             flow: Right
-            padding: {left: 4, right: 4}
-            spacing: 0
+            padding: {left: 8, right: 8}
+            spacing: 6
 
             cursor: Hand
             show_bg: true
@@ -136,7 +136,7 @@ live_design! {
                     height: Fit,
                     padding: 0
                     draw_text:{
-                        text_style: <BOLD_FONT>{font_size: 8},
+                        text_style: <BOLD_FONT>{font_size: 9},
                         color: #475467,
                     }
                 }
@@ -172,7 +172,7 @@ live_design! {
                                 width: Fill,
                                 height: Fit,
                                 draw_text: {
-                                    text_style: <REGULAR_FONT>{font_size: 9.5},
+                                    text_style: <REGULAR_FONT>{font_size: 10},
                                     color: #101828,
                                 }
                                 text: ""


### PR DESCRIPTION
### Changes

- Adds a smooth typing "animation" for standard messages, later on to include text fading.
- Enhances font sizing in general for the chat view (mostly upsizing)

DeepInquire does not benefit from this yet, we might want to make a wrapper around the markdown widget that can be re-used in DeepInquire to handle this animation, or just re-implement it independently in DeepInquire (as it might have some differences)

#### Before
https://github.com/user-attachments/assets/515787c0-28ff-4516-b2a6-f45835f56d21

#### After

https://github.com/user-attachments/assets/22027a3a-6668-47d9-93cd-fd5947434267

