### PR TITLE
Provider sync improvements

### DIFF
--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -305,7 +305,21 @@ impl Widget for ModelSelector {
         let store = scope.data.get::<Store>().unwrap();
         let choose_label = self.label(id!(choose.label));
 
-        if self.currently_selected_model.is_none() {
+        if let ProviderSyncingStatus::Syncing(_syncing) = &store.provider_syncing_status {
+            self.view(id!(choose)).set_visible(cx, true);
+            self.view(id!(icon_drop)).set_visible(cx, false);
+            self.view(id!(selected_bot)).set_visible(cx, false);
+            choose_label.set_text(cx, "Syncing assistants...");
+            let color = vec3(0.0, 0.0, 0.0);
+            choose_label.apply_over(
+                cx,
+                live! {
+                    draw_text: {
+                        color: (color)
+                    }
+                },
+            );
+        } else if self.currently_selected_model.is_none() {
             self.view(id!(choose)).set_visible(cx, true);
             self.view(id!(selected_bot)).set_visible(cx, false);
             let color = vec3(0.0, 0.0, 0.0);
@@ -326,20 +340,6 @@ impl Widget for ModelSelector {
                 choose_label.set_text(cx, "No assistants available, check your provider settings");
                 self.view(id!(icon_drop)).set_visible(cx, false);
             }
-        } else if let ProviderSyncingStatus::Syncing(_syncing) = &store.provider_syncing_status {
-            self.view(id!(choose)).set_visible(cx, true);
-            self.view(id!(icon_drop)).set_visible(cx, false);
-            self.view(id!(selected_bot)).set_visible(cx, false);
-            choose_label.set_text(cx, "Syncing assistants...");
-            let color = vec3(0.0, 0.0, 0.0);
-            choose_label.apply_over(
-                cx,
-                live! {
-                    draw_text: {
-                        color: (color)
-                    }
-                },
-            );
         } else {
             self.update_selected_model_info(cx, store);
         }

--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -30,12 +30,7 @@ live_design! {
         flow: Overlay,
 
         align: {x: 0.5, y: 0.5}
-        loading = <ModelSelectorLoading> {
-            width: Fill,
-            height: Fill,
-            visible: false,
-        }
-
+        loading = <ModelSelectorLoading> {}
 
         <View> {
             width: Fill,
@@ -294,10 +289,7 @@ impl Widget for ModelSelector {
 
         // Trigger a redraw if the provider syncing status has changed
         if let ProviderSyncingStatus::Syncing(_syncing) = &store.provider_syncing_status {
-            // TODO: use the syncing info to show a progress bar instead.
             self.model_selector_loading(id!(loading)).show_and_animate(cx);
-        } else {
-            self.model_selector_loading(id!(loading)).hide();
         }
     }
 
@@ -305,11 +297,11 @@ impl Widget for ModelSelector {
         let store = scope.data.get::<Store>().unwrap();
         let choose_label = self.label(id!(choose.label));
 
-        if let ProviderSyncingStatus::Syncing(_syncing) = &store.provider_syncing_status {
+        if let ProviderSyncingStatus::Syncing(syncing) = &store.provider_syncing_status {
             self.view(id!(choose)).set_visible(cx, true);
             self.view(id!(icon_drop)).set_visible(cx, false);
             self.view(id!(selected_bot)).set_visible(cx, false);
-            choose_label.set_text(cx, "Syncing assistants...");
+            choose_label.set_text(cx, &format!("Syncing providers... {}/{}", syncing.current, syncing.total));
             let color = vec3(0.0, 0.0, 0.0);
             choose_label.apply_over(
                 cx,

--- a/src/chat/model_selector_loading.rs
+++ b/src/chat/model_selector_loading.rs
@@ -1,4 +1,5 @@
 use makepad_widgets::*;
+use crate::data::store::{ProviderSyncingStatus, ProviderSyncing, Store};
 
 live_design! {
     use link::theme::*;
@@ -11,36 +12,52 @@ live_design! {
 
     ANIMATION_SPEED = 1.2;
 
-    Bar = <RoundedView> {
+    ProgressBarContainer = <View> {
         width: Fill,
-        height: 8,
-        show_bg: true,
-        draw_bg: {
-            instance border_radius: 1.0,
-            instance dither: 0.9
+        height: 10,
+        flow: Overlay,
+        align: {x: 0.0, y: 0.5},
 
-            fn get_color(self) -> vec4 {
-                return mix(
-                    #F3FFA2,
-                    #B0CBC6,
-                    self.pos.x + self.dither
-                )
+        background = <RoundedView> {
+            width: 500,
+            height: 10,
+            draw_bg: {
+                color: #D9D9D9,
+                border_radius: 2.0,
             }
+        }
 
-            fn pixel(self) -> vec4 {
-                let sdf = Sdf2d::viewport(self.pos * self.rect_size)
-                sdf.box(
-                    self.border_size,
-                    self.border_size,
-                    self.rect_size.x - (self.border_size * 2.0),
-                    self.rect_size.y - (self.border_size * 2.0),
-                    max(1.0, self.border_radius)
-                )
-                sdf.fill_keep(self.get_color())
-                if self.border_size > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_size)
+        progress_bar = <RoundedView> {
+            width: 0,
+            height: 10,
+            draw_bg: {
+                color: #F3FFA2,
+                border_radius: 2.0,
+                instance dither: 0.9
+
+                fn get_color(self) -> vec4 {
+                    return mix(
+                        #F3FFA2,
+                        #B0CBC6,
+                        self.pos.x + self.dither
+                    )
                 }
-                return sdf.result;
+
+                fn pixel(self) -> vec4 {
+                    let sdf = Sdf2d::viewport(self.pos * self.rect_size)
+                    sdf.box(
+                        self.border_size,
+                        self.border_size,
+                        self.rect_size.x - (self.border_size * 2.0),
+                        self.rect_size.y - (self.border_size * 2.0),
+                        max(1.0, self.border_radius)
+                    )
+                    sdf.fill_keep(self.get_color())
+                    if self.border_size > 0.0 {
+                        sdf.stroke(self.get_border_color(), self.border_size)
+                    }
+                    return sdf.result;
+                }
             }
         }
     }
@@ -49,8 +66,14 @@ live_design! {
         width: Fill,
         height: Fill,
         align: {x: 0, y: 1},
+        flow: Down
 
-        line = <Bar> {}
+        <View> {
+            width: Fill,
+            height: Fill,            
+        }
+
+        progress_container = <ProgressBarContainer> {}
 
         animator: {
             line = {
@@ -58,12 +81,12 @@ live_design! {
                 restart = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {line = { draw_bg: {dither: 0.6} }}
+                    apply: {progress_container = { progress_bar = { draw_bg: {dither: 0.6} }}}
                 }
                 run = {
                     redraw: true,
                     from: {all: Forward {duration: (ANIMATION_SPEED)}}
-                    apply: {line = { draw_bg: {dither: 0.0} }}
+                    apply: {progress_container = { progress_bar = { draw_bg: {dither: 0.0} }}}
                 }
             }
         }
@@ -80,6 +103,18 @@ pub struct ModelSelectorLoading {
 
     #[rust]
     timer: Timer,
+    
+    #[rust]
+    progress: f64,
+    
+    #[rust]
+    was_syncing: bool,
+    
+    #[rust]
+    last_syncing_progress: f64,
+    
+    #[rust]
+    hide_timer: Timer,
 }
 
 impl Widget for ModelSelectorLoading {
@@ -87,6 +122,11 @@ impl Widget for ModelSelectorLoading {
         if self.timer.is_event(event).is_some() {
             self.update_animation(cx);
         }
+        
+        if self.hide_timer.is_event(event).is_some() {
+            self.hide_progress_components(cx);
+        }
+        
         if self.animator_handle_event(cx, event).must_redraw() {
             self.redraw(cx);
         }
@@ -95,6 +135,19 @@ impl Widget for ModelSelectorLoading {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        if let Some(store) = scope.data.get::<Store>() {
+            // Check if we're syncing
+            if let ProviderSyncingStatus::Syncing(syncing) = &store.provider_syncing_status {
+                self.was_syncing = true;
+                self.show_progress_components(cx);
+                self.update_progress_bar(cx, syncing);
+            } else if self.was_syncing {
+                // We just finished syncing - animate to completion
+                self.was_syncing = false;
+                self.complete_progress_bar(cx);
+            }
+        }
+        
         self.view.draw_walk(cx, scope, walk)
     }
 }
@@ -102,12 +155,68 @@ impl Widget for ModelSelectorLoading {
 impl ModelSelectorLoading {
     pub fn update_animation(&mut self, cx: &mut Cx) {
         self.visible = true;
+        
         if self.animator_in_state(cx, id!(line.restart)) {
             self.animator_play(cx, id!(line.run));
         } else {
             self.animator_play(cx, id!(line.restart));
         }
         self.timer = cx.start_timeout(1.5);
+    }
+    
+    fn update_progress_bar(&mut self, cx: &mut Cx, syncing: &ProviderSyncing) {
+        let progress_percentage = if syncing.total > 0 {
+            syncing.current as f64 / syncing.total as f64
+        } else {
+            0.0
+        };
+        
+        // Update our stored progress values
+        self.progress = progress_percentage;
+        self.last_syncing_progress = progress_percentage;
+        
+        // Calculate the width - 5.0 is the multiplier (500px / 100%)
+        let progress_bar_width = progress_percentage * 5.0 * 100.0;
+        
+        self.view(id!(progress_container.progress_bar)).apply_over(
+            cx,
+            live! {
+                width: (progress_bar_width)
+            }
+        );
+    }
+    
+    fn complete_progress_bar(&mut self, cx: &mut Cx) {
+        // Always animate to full width before disappearing
+        // Set width to full 500px to ensure it completes
+        self.view(id!(progress_container.progress_bar)).apply_over(
+            cx,
+            live! {
+                width: 500.0
+            }
+        );
+        
+        // Set a timer to hide the progress bar components after a short delay
+        self.hide_timer = cx.start_timeout(0.3);
+    }
+    
+    fn hide_progress_components(&mut self, cx: &mut Cx) {
+        self.view(id!(progress_container.background)).set_visible(cx, false);
+        
+        self.view(id!(progress_container.progress_bar)).apply_over(
+            cx,
+            live! {
+                visible: false,
+                width: 0.0
+            }
+        );
+        
+        self.redraw(cx);
+    }
+
+    fn show_progress_components(&mut self, cx: &mut Cx) {
+        self.view(id!(progress_container.background)).set_visible(cx, true);
+        self.view(id!(progress_container.progress_bar)).set_visible(cx, true);
     }
 }
 
@@ -116,16 +225,9 @@ impl ModelSelectorLoadingRef {
         let Some(mut inner) = self.borrow_mut() else {
             return;
         };
+        inner.visible = true;
         if inner.timer.is_empty() {
             inner.timer = cx.start_timeout(0.2);
         }
-    }
-
-    pub fn hide(&mut self) {
-        let Some(mut inner) = self.borrow_mut() else {
-            return;
-        };
-        inner.visible = false;
-        inner.timer = Timer::default();
     }
 }

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -14,7 +14,7 @@ use super::filesystem::setup_chats_folder;
 use super::moly_client::MolyClient;
 use super::preferences::Preferences;
 use super::providers::{create_client_for_provider, Provider, ProviderClient, ProviderFetchModelsResult, ProviderType, ProviderBot, ProviderConnectionStatus};
-use super::store::ProviderSyncingStatus;
+use super::store::{ProviderSyncingStatus, ProviderSyncing};
 
 pub struct Chats {
     pub moly_client: Arc<MolyClient>,
@@ -153,12 +153,28 @@ impl Chats {
         chat.borrow().remove_saved_file();
     }
 
-    pub fn register_provider(&mut self, provider: Provider) {
+    /// Registers a provider to listen to and the provider info.
+    ///
+    /// When calling this function, the provider will be tested for connectivity and
+    /// the models will be fetched.
+    pub fn register_provider(&mut self, provider: Provider, provider_syncing_status: &mut ProviderSyncingStatus) {
         self.providers.insert(provider.url.clone(), provider.clone());
-        self.test_provider_and_fetch_models(&provider.url);
+        self.test_provider_and_fetch_models(&provider.url, provider_syncing_status);
     }
 
-    pub fn test_provider_and_fetch_models(&mut self, address: &str) {
+    pub fn test_provider_and_fetch_models(&mut self, address: &str, provider_syncing_status: &mut ProviderSyncingStatus) {
+        // Update syncing status
+        if let ProviderSyncingStatus::Syncing(syncing) = provider_syncing_status {
+            // If already syncing, increment the total count
+            syncing.total += 1;
+        } else {
+            // Otherwise, start new syncing status with 1 provider
+            *provider_syncing_status = ProviderSyncingStatus::Syncing(ProviderSyncing {
+                current: 0,
+                total: 1,
+            });
+        }
+
         // Use the existing client if found, otherwise create a new one
         let client = if let Some(existing_client) = self.provider_clients.get(address) {
             existing_client
@@ -281,7 +297,13 @@ impl Chats {
         fetched_from_moly_server
     }
 
-    pub fn insert_or_update_provider(&mut self, provider: &Provider) {
+    /// Inserts or updates a provider in the list of providers.
+    /// 
+    /// If the provider is already in the list, it updates the provider info and the client.
+    /// If the provider is not in the list, it registers the provider and creates a new client.
+    /// 
+    /// Automatically tests the provider and fetches models, both on new providers and on API key changes.
+    pub fn insert_or_update_provider(&mut self, provider: &Provider, provider_syncing_status: &mut ProviderSyncingStatus) {
         // If the provider is already in the list update it, and create a new client if there's a new API key
         if let Some(existing_provider) = self.providers.get_mut(&provider.url) {
             existing_provider.api_key = provider.api_key.clone();
@@ -295,9 +317,14 @@ impl Chats {
                 // skipping that for now as the client will be replaced by MolyKit
                 self.provider_clients.remove(&provider.url);
                 self.provider_clients.insert(provider.url.clone(), create_client_for_provider(provider));
+            
+            }
+
+            if provider.enabled {
+                self.test_provider_and_fetch_models(&provider.url, provider_syncing_status);
             }
         } else {
-            self.providers.insert(provider.url.clone(), provider.clone());
+            self.register_provider(provider.clone(), provider_syncing_status);
             self.provider_clients.insert(provider.url.clone(), create_client_for_provider(provider));
         }
     }

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -171,12 +171,16 @@ impl Chats {
         client.fetch_models();
     }
 
+    /// Handle the result of a provider fetching models operation.
+    /// 
+    /// Returns true if the provider is MolyServer and the fetching was successful.
     pub fn handle_provider_connection_result(
         &mut self,
         result: ProviderFetchModelsResult,
         preferences: &mut Preferences,
         provider_syncing_status: &mut ProviderSyncingStatus
-    ) {
+    ) -> bool {
+        let mut fetched_from_moly_server = false;
         match result {
             ProviderFetchModelsResult::Success(address, mut fetched_models) => {
 
@@ -246,6 +250,10 @@ impl Chats {
 
                 if let Some(provider) = self.providers.get_mut(&address) {
                     provider.connection_status = ProviderConnectionStatus::Connected;
+                    // If the fetching was successful and the provider is MolyServer, sync status
+                    if provider.provider_type == ProviderType::MolyServer {
+                        fetched_from_moly_server = true;
+                    }
                 }
             }
             ProviderFetchModelsResult::Failure(address, error) => {
@@ -269,6 +277,8 @@ impl Chats {
             }
             _ => {}
         }
+
+        fetched_from_moly_server
     }
 
     pub fn insert_or_update_provider(&mut self, provider: &Provider) {

--- a/src/data/openai_client.rs
+++ b/src/data/openai_client.rs
@@ -62,7 +62,7 @@ impl OpenAIClient {
                 ProviderCommand::FetchModels() => {
                     let url = address.clone();
                     let client = reqwest::blocking::ClientBuilder::new()
-                        .timeout(std::time::Duration::from_secs(5))
+                        .timeout(std::time::Duration::from_secs(60))
                         .no_proxy()
                         .build()
                         .unwrap();

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -266,18 +266,6 @@ impl Store {
         }
     }
 
-    /// Set the provider syncing status to indicate a single provider is being synced
-    pub fn set_syncing_single_provider(&mut self) {
-        // TODO: this is called in multiple places usually besides test_provider_and_fetch_models
-        // we should refactor this to avoid code duplication. Ideally we'd call this function
-        // from test_provider_and_fetch_models and have it increase the syncing count instead of resetting to 1
-        // (if we have more than one provider to sync).
-        self.provider_syncing_status = ProviderSyncingStatus::Syncing(ProviderSyncing {
-            current: 0,
-            total: 1,
-        });
-    }
-
     /// Loads the preference connections from the preferences and registers them in the chats.
     pub fn load_preference_connections(&mut self) {
         let supported = supported_providers::load_supported_providers();
@@ -357,22 +345,20 @@ impl Store {
             .map(|pp| pp.url.clone())
             .collect();
 
-        self.provider_syncing_status = ProviderSyncingStatus::Syncing(ProviderSyncing {
-            current: 0,
-            total: urls_to_fetch.len() as u32,
-        });
-
-        for url in urls_to_fetch {
-            if let Some(provider) = self.chats.providers.get(&url) {
-                // Register the provider client, it triggers test_provider_and_fetch_models internally
-                self.chats.register_provider(provider.clone());
-            }
+        // Collect providers first to avoid borrow issues
+        let providers_to_register: Vec<Provider> = urls_to_fetch
+            .iter()
+            .filter_map(|url| self.chats.providers.get(url).cloned())
+            .collect();
+        
+        for provider in providers_to_register {
+            self.chats.register_provider(provider, &mut self.provider_syncing_status);
         }
     }
 
     pub fn insert_or_update_provider(&mut self, provider: &Provider) {
         // Update in memory
-        self.chats.insert_or_update_provider(provider);
+        self.chats.insert_or_update_provider(provider, &mut self.provider_syncing_status);
         // Update in preferences (persist in disk)
         self.preferences.insert_or_update_provider(provider);
         // Update in MolyKit (to update the API key used by the client, if needed)

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -19,8 +19,8 @@ use makepad_widgets::{Action, ActionDefaultRef, DefaultNone};
 use super::providers::{Provider, ProviderConnectionStatus};
 use moly_protocol::data::{Author, File, FileID, Model, ModelID, PendingDownload};
 
-use moly_kit::*;
 use makepad_widgets::*;
+use moly_kit::*;
 
 #[allow(dead_code)]
 const DEFAULT_MOFA_ADDRESS: &str = "http://localhost:8000";
@@ -108,7 +108,7 @@ impl Store {
 
         store.chats.load_chats();
         store.init_current_chat();
-        
+
         store.sync_with_moly_server();
         store.load_preference_connections();
 
@@ -144,13 +144,15 @@ impl Store {
                     self.downloads.load_pending_downloads();
                     self.search.load_featured_models();
                 }
-                Err(_err) => {},
+                Err(_err) => {}
             }
         };
     }
 
     pub fn get_chat_associated_bot(&self, chat_id: ChatID) -> Option<BotId> {
-        self.chats.get_chat_by_id(chat_id).and_then(|chat| chat.borrow().associated_bot.clone())
+        self.chats
+            .get_chat_by_id(chat_id)
+            .and_then(|chat| chat.borrow().associated_bot.clone())
     }
 
     /// This function combines the search results information for a given model
@@ -251,8 +253,17 @@ impl Store {
     }
 
     pub fn handle_provider_connection_action(&mut self, result: ProviderFetchModelsResult) {
-        if let ProviderFetchModelsResult::None = result { return; }
-        self.chats.handle_provider_connection_result(result, &mut self.preferences, &mut self.provider_syncing_status);
+        if let ProviderFetchModelsResult::None = result {
+            return;
+        }
+        let fetched_from_moly_server = self.chats.handle_provider_connection_result(
+            result,
+            &mut self.preferences,
+            &mut self.provider_syncing_status,
+        );
+        if fetched_from_moly_server && !self.moly_client.is_connected() {
+            self.sync_with_moly_server();
+        }
     }
 
     /// Loads the preference connections from the preferences and registers them in the chats.
@@ -261,7 +272,9 @@ impl Store {
         let mut final_list = Vec::new();
 
         for s in &supported {
-            let maybe_prefs = self.preferences.providers_preferences
+            let maybe_prefs = self
+                .preferences
+                .providers_preferences
                 .iter()
                 .find(|pp| pp.url == s.url);
 
@@ -317,10 +330,18 @@ impl Store {
 
     fn auto_fetch_for_enabled_providers(&mut self) {
         // Automatically fetch providers that are enabled and have an API key or are MoFa servers
-        let urls_to_fetch: Vec<String> = self.preferences.providers_preferences
+        let urls_to_fetch: Vec<String> = self
+            .preferences
+            .providers_preferences
             .iter()
             // TODO: If the provider requires an API key, we should fetch only if the API key is set
-            .filter(|pp| pp.enabled && (pp.api_key.is_some() || pp.provider_type == ProviderType::MoFa || pp.provider_type == ProviderType::DeepInquire || pp.url.starts_with("http://localhost")))
+            .filter(|pp| {
+                pp.enabled
+                    && (pp.api_key.is_some()
+                        || pp.provider_type == ProviderType::MoFa
+                        || pp.provider_type == ProviderType::DeepInquire
+                        || pp.url.starts_with("http://localhost"))
+            })
             .map(|pp| pp.url.clone())
             .collect();
 

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -266,6 +266,18 @@ impl Store {
         }
     }
 
+    /// Set the provider syncing status to indicate a single provider is being synced
+    pub fn set_syncing_single_provider(&mut self) {
+        // TODO: this is called in multiple places usually besides test_provider_and_fetch_models
+        // we should refactor this to avoid code duplication. Ideally we'd call this function
+        // from test_provider_and_fetch_models and have it increase the syncing count instead of resetting to 1
+        // (if we have more than one provider to sync).
+        self.provider_syncing_status = ProviderSyncingStatus::Syncing(ProviderSyncing {
+            current: 0,
+            total: 1,
+        });
+    }
+
     /// Loads the preference connections from the preferences and registers them in the chats.
     pub fn load_preference_connections(&mut self) {
         let supported = supported_providers::load_supported_providers();

--- a/src/settings/add_provider_modal.rs
+++ b/src/settings/add_provider_modal.rs
@@ -377,7 +377,6 @@ impl WidgetMatchEvent for AddProviderModal {
             };
 
             store.insert_or_update_provider(&provider);
-            store.chats.test_provider_and_fetch_models(&provider.url);
 
             cx.action(AddProviderModalAction::ModalDismissed);
             self.clear_form(cx);

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -331,6 +331,8 @@ impl WidgetMatchEvent for ProviderView {
         let provider_enabled_switch = self.check_box(id!(provider_enabled_switch));
         if let Some(enabled) = provider_enabled_switch.changed(actions) {
             if enabled {
+                // Set status to syncing before fetching models
+                store.set_syncing_single_provider();
                 store.chats.test_provider_and_fetch_models(&self.provider.url);
             }
 
@@ -374,8 +376,12 @@ impl WidgetMatchEvent for ProviderView {
             self.provider.connection_status = ProviderConnectionStatus::Connecting;
             // Update the provider in the store and preferences
             store.insert_or_update_provider(&self.provider);
+            
+            // Set status to syncing before fetching models
+            store.set_syncing_single_provider();
             // Fetch the models from the provider
             store.chats.test_provider_and_fetch_models(&self.provider.url);
+            
             // Update the provider enabled switch
             self.check_box(id!(provider_enabled_switch)).set_active(cx, true);
             // Update the UI
@@ -388,8 +394,12 @@ impl WidgetMatchEvent for ProviderView {
             // Update the provider status in the store
             self.provider.connection_status = ProviderConnectionStatus::Connecting;
             store.insert_or_update_provider(&self.provider);
+            
+            // Set status to syncing before fetching models
+            store.set_syncing_single_provider();
             // Fetch the models from the provider
             store.chats.test_provider_and_fetch_models(&self.provider.url);
+            
             // Update UI
             self.update_connection_status(cx);
             self.redraw(cx);

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -330,12 +330,6 @@ impl WidgetMatchEvent for ProviderView {
         // Handle provider enabled/disabled
         let provider_enabled_switch = self.check_box(id!(provider_enabled_switch));
         if let Some(enabled) = provider_enabled_switch.changed(actions) {
-            if enabled {
-                // Set status to syncing before fetching models
-                store.set_syncing_single_provider();
-                store.chats.test_provider_and_fetch_models(&self.provider.url);
-            }
-
             self.provider.enabled = enabled;
             // Update the provider in store and preferences
             store.insert_or_update_provider(&self.provider);
@@ -377,11 +371,6 @@ impl WidgetMatchEvent for ProviderView {
             // Update the provider in the store and preferences
             store.insert_or_update_provider(&self.provider);
             
-            // Set status to syncing before fetching models
-            store.set_syncing_single_provider();
-            // Fetch the models from the provider
-            store.chats.test_provider_and_fetch_models(&self.provider.url);
-            
             // Update the provider enabled switch
             self.check_box(id!(provider_enabled_switch)).set_active(cx, true);
             // Update the UI
@@ -394,11 +383,6 @@ impl WidgetMatchEvent for ProviderView {
             // Update the provider status in the store
             self.provider.connection_status = ProviderConnectionStatus::Connecting;
             store.insert_or_update_provider(&self.provider);
-            
-            // Set status to syncing before fetching models
-            store.set_syncing_single_provider();
-            // Fetch the models from the provider
-            store.chats.test_provider_and_fetch_models(&self.provider.url);
             
             // Update UI
             self.update_connection_status(cx);

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -282,7 +282,7 @@ impl Widget for ProviderView {
 
                         let name = models[item_id].human_readable_name();
                         item.label(id!(model_name)).set_text(cx, &name);
-                        item.check_box(id!(enabled_switch)).set_active(cx, models[item_id].enabled);
+                        item.check_box(id!(enabled_switch)).set_active(cx, models[item_id].enabled && self.provider.enabled);
 
                         item.as_model_entry().set_model_name(&models[item_id].name);
                         item.draw_all(cx, scope);

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -100,6 +100,7 @@ live_design! {
                     width: Fit, height: Fit
                     flow: Right, spacing: 10
                     refresh_button = <View> {
+                        visible: false
                         padding: {top: 4} // TODO: this is a hack to align the image view with the switch
                         cursor: Hand
                         width: 30, height: 30
@@ -258,6 +259,12 @@ impl Widget for ProviderView {
         // Catch up with the latest provider status in the store
         self.provider = store.chats.providers.get(&self.provider.url).unwrap().clone();
         self.update_connection_status(cx);
+
+        if self.provider.enabled {
+            self.view(id!(refresh_button)).set_visible(cx, true);
+        } else {
+            self.view(id!(refresh_button)).set_visible(cx, false);
+        }
 
         let entries_count = models.len();
         while let Some(item) = self.view.draw_walk(cx, scope, walk).step() {


### PR DESCRIPTION
### Changes

- Fixes bugs with MolyServer, BotRepo and Providers hash map being out of sync
- Updates syncing status when updating single providers (not just in startup)
- Refactors provider registration to handle syncing/fetching models internally
- Show models as disabled in Provider view if the provider is disabled
- Makes the model loader loading line into a progress bar