### PR TITLE
Improve thinking blocks

### DIFF
--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -352,7 +352,7 @@ impl BotClient for OpenAIClient {
                         content.text.push_str(&choice.delta.content);
                     }
 
-                    // Extract reasoning text, preferring "reasoning" but falling back to "reasoning_content"
+                    // Extract reasoning text, could be found in "reasoning" or "reasoning_content"
                     let mut actual_reasoning_delta_text: Option<&str> = None;
                     if let Some(r_text) = &choice.delta.reasoning {
                         if !r_text.is_empty() {

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -116,6 +116,9 @@ pub struct MessageContent {
     /// List of citations/sources (urls) associated with this message.
     pub citations: Vec<String>,
 
+    /// The reasoning/thinking text provided by the bot for this message.
+    pub reasoning: Option<String>,
+
     /// Non-standard data contained by this message.
     ///
     /// May be used by clients for tracking purposes or to represent unsupported

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -116,8 +116,8 @@ pub struct MessageContent {
     /// List of citations/sources (urls) associated with this message.
     pub citations: Vec<String>,
 
-    /// The reasoning/thinking text provided by the bot for this message.
-    pub reasoning: Option<String>,
+    /// The reasoning/thinking content of this message.
+    pub reasoning: Option<Reasoning>,
 
     /// Non-standard data contained by this message.
     ///
@@ -142,6 +142,13 @@ impl MessageContent {
     pub fn is_empty(&self) -> bool {
         self.text.is_empty() && self.citations.is_empty() && self.data.is_none()
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
+pub struct Reasoning {
+    pub text: String,
+    pub time_taken_seconds: Option<f64>,
 }
 
 /// A message that is part of a conversation.

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -362,7 +362,8 @@ impl Messages {
                         .map(|b| (b.name.as_str(), Some(b.avatar.clone())))
                         .unwrap_or(("Unknown bot", Some(Picture::Grapheme("B".into()))));
 
-                    let item = if message.is_writing && message.content.is_empty() {
+                    // Show a loading animation if there if the message is being streamed and there's no valuable content to show yet.
+                    let item = if message.is_writing && message.content.is_empty() && message.content.reasoning.is_none() {
                         let item = list.item(cx, index, live_id!(LoadingLine));
                         item.message_loading(id!(content_section.loading))
                             .animate(cx);

--- a/moly-kit/src/widgets/standard_message_content.rs
+++ b/moly-kit/src/widgets/standard_message_content.rs
@@ -78,17 +78,10 @@ impl StandardMessageContent {
         citation_list.borrow_mut().unwrap().urls = content.citations.clone();
         citation_list.borrow_mut().unwrap().visible = !content.citations.is_empty();
 
-        let mut final_thinking_text: Option<String> = None;
-
-        // Prioritize content.reasoning if available and not empty
         if let Some(reasoning) = &content.reasoning {
-            if !reasoning.is_empty() {
-                final_thinking_text = Some(reasoning.clone());
-            }
+            self.message_thinking_block(id!(thinking_block))
+                .set_thinking_content(cx, reasoning, is_writing);
         }
-
-        self.message_thinking_block(id!(thinking_block))
-            .set_thinking_text(cx, final_thinking_text, is_writing);
 
         if !content.text.is_empty() {
             if is_writing {


### PR DESCRIPTION
### Changes

- Restores thinking blocks, recently they stopped working in Moly due to API changes on major providers. Instead of including the thinking content within <think> tags in the message content, providers now use a separate field, usually `reasoning` or `reasoning_content`.
- Improved the UI of thinking blocks and added an animation to show that thinking is happening.


https://github.com/user-attachments/assets/2111ea27-2ad5-4691-827c-abb085b3ff03

