### PR TITLE
Some pending renaming and deleting from moly kit

### DIFF
--- a/book/src/custom-client.md
+++ b/book/src/custom-client.md
@@ -45,7 +45,7 @@ impl BotClient for MyCustomClient {
 
     fn send(
         &mut self,
-        bot: &Bot,
+        bot_id: &BotId,
         messages: &[Message],
     ) -> MolyStream<'static, ClientResult<MessageContent>> {
         let stream = stream! {
@@ -121,7 +121,7 @@ impl BotClient for EchoClient {
 
     fn send(
         &mut self,
-        _bot: &Bot,
+        _bot_id: &BotId,
         messages: &[Message],
     ) -> MolyStream<'static, ClientResult<MessageContent>> {
         let last = messages.last().map(|m| m.content.text.clone()).unwrap_or_default();

--- a/book/src/custom-client.md
+++ b/book/src/custom-client.md
@@ -43,7 +43,7 @@ impl BotClient for MyCustomClient {
         moly_future(future)
     }
 
-    fn send_stream(
+    fn send(
         &mut self,
         bot: &Bot,
         messages: &[Message],
@@ -90,7 +90,7 @@ a list of available models/agents. It's pretty simple to implement; you could us
 something like `reqwest` to fetch some JSON from your provider with the list of models,
 parse that, and return it.
 
-`send_stream` is the method that sends a message to a model/agent. It returns a
+`send` is the method that sends a message to a model/agent. It returns a
 stream which allows you to push chunks of content in real-time. Although, you
 could also yield a single chunk from it if you don't support streaming.
 
@@ -119,7 +119,7 @@ impl BotClient for EchoClient {
         moly_future(future)
     }
 
-    fn send_stream(
+    fn send(
         &mut self,
         _bot: &Bot,
         messages: &[Message],

--- a/book/src/custom-content.md
+++ b/book/src/custom-content.md
@@ -100,7 +100,7 @@ impl BotClient for MyCustomClient {
             return None;
         };
 
-        // Let's assume `MessageContent` yielded from our `send_stream` contains
+        // Let's assume `MessageContent` yielded from our `send` contains
         // this arbitrary data, explicitly stating it wants to be rendered with
         // `MyCustomContent`.
         if data != "I want to be displayed with MyCustomContent widget" {

--- a/book/src/integrate.md
+++ b/book/src/integrate.md
@@ -5,7 +5,7 @@ This guide assumes you have already read the [Quickstart](quickstart.md).
 
 ## Introduction
 
-As we saw before, we only need to give a `BotRepo` to `Chat`, and then it just works.
+As we saw before, we only need to give a `BotContext` to `Chat`, and then it just works.
 The `Chat` widget is designed to work on its own after initial configuration, without
 you needing to do anything else.
 

--- a/book/src/multiple-providers.md
+++ b/book/src/multiple-providers.md
@@ -6,14 +6,14 @@ This guide assumes you already read the [Quickstart](quickstart.md).
 
 ## Mixing clients
 
-As seen before, a `BotRepo` is created from one (and only one) `BotClient`.
+As seen before, a `BotContext` is created from one (and only one) `BotClient`.
 
 If we want out app to be able to use multiple clients configured in different ways
 at the same time, we will need to compose them into one.
 
 Fortunally, Moly Kit comes with a built-in client called `MultiClient`, which does
 exactly that. `MultiClient` can take several "sub-clients" but acts as a single
-one to `BotRepo`, routing requests to them accordengly.
+one to `BotContext`, routing requests to them accordengly.
 
 Going back to our configuration from the [Quickstart](quickstart.md), we can
 update it to work with several clients at the same time:
@@ -40,10 +40,10 @@ impl LiveHook for YourAmazingWidget {
           client
         };
 
-        let repo = BotRepo::from(client);
+        let context = BotContext::from(client);
 
         let mut chat = self.chat(id!(chat));
-        chat.write().bot_repo = repo;
+        chat.write().bot_context = context;
     }
 }
 ```

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -77,10 +77,10 @@ The `Chat` widget as it is will not work. We need to configure some one-time stu
 from the Rust side.
 
 The `Chat` widget pulls information about available bots from a synchronous interface
-called a `BotRepo`. We don't need to understand how it works, but we need to create
+called a `BotContext`. We don't need to understand how it works, but we need to create
 and pass one to `Chat`.
 
-A `BotRepo` can be directly created from a `BotClient`, which is an asynchronous
+A `BotContext` can be directly created from a `BotClient`, which is an asynchronous
 interface to interact with (mostly remote) bot providers like OpenAI, Ollama, OpenRouter,
 Moly Server, MoFa, etc.
 
@@ -100,10 +100,10 @@ impl LiveHook for YourAmazingWidget {
         let mut client = OpenAIClient::new("https://api.openai.com/v1".into());
         client.set_key("<YOUR_KEY>".into());
 
-        let repo = BotRepo::from(client);
+        let context = BotContext::from(client);
 
         let mut chat = self.chat(id!(chat));
-        chat.write().bot_repo = repo;
+        chat.write().bot_context = context;
     }
 }
 ```

--- a/moly-kit/src/clients/deep_inquire.rs
+++ b/moly-kit/src/clients/deep_inquire.rs
@@ -210,7 +210,7 @@ impl BotClient for DeepInquireClient {
         Box::new(self.clone())
     }
 
-    fn send_stream(
+    fn send(
         &mut self,
         bot: &Bot,
         messages: &[Message],

--- a/moly-kit/src/clients/deep_inquire.rs
+++ b/moly-kit/src/clients/deep_inquire.rs
@@ -212,7 +212,7 @@ impl BotClient for DeepInquireClient {
 
     fn send(
         &mut self,
-        bot: &Bot,
+        bot_id: &BotId,
         messages: &[Message],
     ) -> MolyStream<'static, ClientResult<MessageContent>> {
         let inner = self.0.read().unwrap().clone();
@@ -230,7 +230,7 @@ impl BotClient for DeepInquireClient {
             .post(&url)
             .headers(headers)
             .json(&serde_json::json!({
-                "model": bot.id.id(),
+                "model": bot_id.id(),
                 "messages": moly_messages,
                 "stream": true
             }));

--- a/moly-kit/src/clients/multi.rs
+++ b/moly-kit/src/clients/multi.rs
@@ -29,7 +29,7 @@ impl MultiClient {
 }
 
 impl BotClient for MultiClient {
-    fn send_stream(
+    fn send(
         &mut self,
         bot: &Bot,
         messages: &[Message],
@@ -48,7 +48,7 @@ impl BotClient for MultiClient {
             });
 
         match client {
-            Some(mut client) => client.send_stream(bot, messages),
+            Some(mut client) => client.send(bot, messages),
             None => {
                 let bot = bot.clone();
                 moly_stream(futures::stream::once(async move {

--- a/moly-kit/src/clients/multi.rs
+++ b/moly-kit/src/clients/multi.rs
@@ -31,7 +31,7 @@ impl MultiClient {
 impl BotClient for MultiClient {
     fn send(
         &mut self,
-        bot: &Bot,
+        bot_id: &BotId,
         messages: &[Message],
     ) -> MolyStream<'static, ClientResult<MessageContent>> {
         let client = self
@@ -40,7 +40,7 @@ impl BotClient for MultiClient {
             .unwrap()
             .iter()
             .find_map(|(client, bots)| {
-                if bots.iter().any(|b| b.id == bot.id) {
+                if bots.iter().any(|b| b.id == *bot_id) {
                     Some(client.clone())
                 } else {
                     None
@@ -48,13 +48,16 @@ impl BotClient for MultiClient {
             });
 
         match client {
-            Some(mut client) => client.send(bot, messages),
+            Some(mut client) => client.send(bot_id, messages),
             None => {
-                let bot = bot.clone();
+                let bot_id_clone = bot_id.clone();
                 moly_stream(futures::stream::once(async move {
                     ClientError::new(
                         ClientErrorKind::Unknown,
-                        format!("Can't find a client to communicate with the bot {:?}", bot),
+                        format!(
+                            "Can't find a client to communicate with the bot {:?}",
+                            bot_id_clone
+                        ),
                     )
                     .into()
                 }))

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -249,7 +249,7 @@ impl BotClient for OpenAIClient {
     /// Stream pieces of content back as a ChatDelta instead of just a String.
     fn send(
         &mut self,
-        bot: &Bot,
+        bot_id: &BotId,
         messages: &[Message],
     ) -> MolyStream<'static, ClientResult<MessageContent>> {
         let inner = self.0.read().unwrap().clone();
@@ -267,7 +267,7 @@ impl BotClient for OpenAIClient {
             .post(&url)
             .headers(headers)
             .json(&serde_json::json!({
-                "model": bot.id.id(),
+                "model": bot_id.id(),
                 "messages": moly_messages,
                 // Note: o1 only supports 1.0, it will error if other value is used.
                 // "temperature": 0.7,

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -247,7 +247,7 @@ impl BotClient for OpenAIClient {
     }
 
     /// Stream pieces of content back as a ChatDelta instead of just a String.
-    fn send_stream(
+    fn send(
         &mut self,
         bot: &Bot,
         messages: &[Message],

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -439,7 +439,7 @@ impl Clone for Box<dyn BotClient> {
     }
 }
 
-struct InnerBotRepo {
+struct InnerBotContext {
     client: Box<dyn BotClient>,
     bots: Vec<Bot>,
 }
@@ -449,26 +449,26 @@ struct InnerBotRepo {
 ///
 /// Passed down through widgets from this crate.
 ///
-/// Separate chat widgets can share the same [BotRepo] to avoid loading the same
+/// Separate chat widgets can share the same [BotContext] to avoid loading the same
 /// bots multiple times.
-pub struct BotRepo(Arc<Mutex<InnerBotRepo>>);
+pub struct BotContext(Arc<Mutex<InnerBotContext>>);
 
-impl Clone for BotRepo {
+impl Clone for BotContext {
     fn clone(&self) -> Self {
-        BotRepo(self.0.clone())
+        BotContext(self.0.clone())
     }
 }
 
-impl PartialEq for BotRepo {
+impl PartialEq for BotContext {
     fn eq(&self, other: &Self) -> bool {
         self.id() == other.id()
     }
 }
 
-impl BotRepo {
-    /// Differenciates [BotRepo]s.
+impl BotContext {
+    /// Differenciates [BotContext]s.
     ///
-    /// Two [BotRepo]s are equal and share the same underlying data if they have
+    /// Two [BotContext]s are equal and share the same underlying data if they have
     /// the same id.
     pub fn id(&self) -> usize {
         Arc::as_ptr(&self.0) as usize
@@ -508,9 +508,9 @@ impl BotRepo {
     }
 }
 
-impl<T: BotClient + 'static> From<T> for BotRepo {
+impl<T: BotClient + 'static> From<T> for BotContext {
     fn from(client: T) -> Self {
-        BotRepo(Arc::new(Mutex::new(InnerBotRepo {
+        BotContext(Arc::new(Mutex::new(InnerBotContext {
             client: Box::new(client),
             bots: Vec::new(),
         })))

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -395,7 +395,7 @@ pub trait BotClient: Send {
     /// You are free to add, modify or remove content on-the-go.
     fn send(
         &mut self,
-        bot: &Bot,
+        bot_id: &BotId,
         messages: &[Message],
     ) -> MolyStream<'static, ClientResult<MessageContent>>;
 

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -319,7 +319,7 @@ impl Chat {
                 }
             };
 
-            let mut message_stream = client.send(&bot, &context);
+            let mut message_stream = client.send(&bot.id, &context);
             while let Some(result) = message_stream.next().await {
                 // In theory, with the synchroneous defer, if stream messages come
                 // faster than deferred closures are executed, and one closure causes

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -76,13 +76,13 @@ pub struct Chat {
     #[deref]
     deref: View,
 
-    /// The bot repository used by this chat to hold bots and interact with them.
+    /// The [BotContext] used by this chat to hold bots and interact with them.
     #[rust]
-    pub bot_repo: Option<BotRepo>,
+    pub bot_context: Option<BotContext>,
 
     /// The id of the bot the chat will message when sending.
     // TODO: Can this be live?
-    // TODO: Default to the first bot in the repo if `None`.
+    // TODO: Default to the first bot in [BotContext] if `None`.
     #[rust]
     pub bot_id: Option<BotId>,
 
@@ -117,10 +117,10 @@ pub struct Chat {
 
 impl Widget for Chat {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        // Pass down the bot repo if not the same.
+        // Pass down the BotContext if not the same.
         self.messages_ref().write_with(|m| {
-            if m.bot_repo != self.bot_repo {
-                m.bot_repo = self.bot_repo.clone();
+            if m.bot_context != self.bot_context {
+                m.bot_context = self.bot_context.clone();
             }
         });
 
@@ -242,14 +242,14 @@ impl Chat {
         // TODO: See `bot_id` TODO.
         let bot_id = self.bot_id.clone().expect("no bot selected");
 
-        let repo = self
-            .bot_repo
+        let context = self
+            .bot_context
             .as_ref()
-            .expect("no bot repo provided")
+            .expect("no BotContext provided")
             .clone();
 
-        // First check if the bot exists in the repository
-        if repo.get_bot(&bot_id).is_none() {
+        // First check if the bot exists in the BotContext.
+        if context.get_bot(&bot_id).is_none() {
             // Bot not found, add error message
             let next_index = self.messages_ref().read().messages.len();
             let error_message = format!(
@@ -270,8 +270,8 @@ impl Chat {
             return;
         }
 
-        let context: Vec<Message> = self.messages_ref().write_with(|messages| {
-            messages.bot_repo = Some(repo.clone());
+        let messages_history_context: Vec<Message> = self.messages_ref().write_with(|messages| {
+            messages.bot_context = Some(context.clone());
 
             messages.messages.push(Message {
                 from: EntityId::Bot(bot_id.clone()),
@@ -293,8 +293,8 @@ impl Chat {
 
         let ui = self.ui_runner();
         let future = async move {
-            let mut client = repo.client();
-            let bot = match repo.get_bot(&bot_id) {
+            let mut client = context.client();
+            let bot = match context.get_bot(&bot_id) {
                 Some(bot) => bot,
                 None => {
                     // This should never happen as we check above, but handle it gracefully anyway
@@ -319,7 +319,7 @@ impl Chat {
                 }
             };
 
-            let mut message_stream = client.send(&bot.id, &context);
+            let mut message_stream = client.send(&bot.id, &messages_history_context);
             while let Some(result) = message_stream.next().await {
                 // In theory, with the synchroneous defer, if stream messages come
                 // faster than deferred closures are executed, and one closure causes

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -59,7 +59,7 @@ pub enum ChatTask {
     ClearPrompt,
 
     /// When received back, the chat will scroll to the bottom.
-    /// 
+    ///
     /// The boolean indicates if the scroll was triggered by a stream or not.
     ScrollToBottom(bool),
 }
@@ -252,8 +252,11 @@ impl Chat {
         if repo.get_bot(&bot_id).is_none() {
             // Bot not found, add error message
             let next_index = self.messages_ref().read().messages.len();
-            let error_message = format!("App error: Bot not found. The bot might have been disabled or removed. Bot ID: {}", bot_id);
-            
+            let error_message = format!(
+                "App error: Bot not found. The bot might have been disabled or removed. Bot ID: {}",
+                bot_id
+            );
+
             let message = Message {
                 from: EntityId::App,
                 content: MessageContent {
@@ -262,7 +265,7 @@ impl Chat {
                 },
                 is_writing: false,
             };
-            
+
             self.dispatch(cx, &mut vec![ChatTask::InsertMessage(next_index, message)]);
             return;
         }
@@ -297,7 +300,10 @@ impl Chat {
                     // This should never happen as we check above, but handle it gracefully anyway
                     let bot_id_clone = bot_id.clone(); // Clone the bot_id for the closure
                     ui.defer_with_redraw(move |me, cx, _| {
-                        let error_message = format!("App error: Bot not found during stream initialization. Bot ID: {}", bot_id_clone);
+                        let error_message = format!(
+                            "App error: Bot not found during stream initialization. Bot ID: {}",
+                            bot_id_clone
+                        );
                         let next_index = me.messages_ref().read().messages.len();
                         let message = Message {
                             from: EntityId::App,
@@ -313,7 +319,7 @@ impl Chat {
                 }
             };
 
-            let mut message_stream = client.send_stream(&bot, &context);
+            let mut message_stream = client.send(&bot, &context);
             while let Some(result) = message_stream.next().await {
                 // In theory, with the synchroneous defer, if stream messages come
                 // faster than deferred closures are executed, and one closure causes
@@ -449,7 +455,9 @@ impl Chat {
                 self.prompt_input_ref().write().reset(cx); // `reset` comes from command text input.
             }
             ChatTask::ScrollToBottom(triggered_by_stream) => {
-                self.messages_ref().write().scroll_to_bottom(cx, *triggered_by_stream);
+                self.messages_ref()
+                    .write()
+                    .scroll_to_bottom(cx, *triggered_by_stream);
             }
         }
     }

--- a/moly-mini/src/demo_chat.rs
+++ b/moly-mini/src/demo_chat.rs
@@ -59,7 +59,7 @@ impl LiveHook for DemoChat {
     fn after_new_from_doc(&mut self, _cx: &mut Cx) {
         // Setup some hooks as an example of how to use them.
         self.setup_chat_hooks();
-        self.setup_chat_repo();
+        self.setup_chat_bot_context();
     }
 }
 
@@ -174,7 +174,7 @@ impl DemoChat {
         });
     }
 
-    fn setup_chat_repo(&self) {
+    fn setup_chat_bot_context(&self) {
         let client = {
             let mut client = MultiClient::new();
 
@@ -211,18 +211,18 @@ impl DemoChat {
             client
         };
 
-        let mut repo: BotRepo = client.into();
-        self.chat(id!(chat)).write().bot_repo = Some(repo.clone());
+        let mut context: BotContext = client.into();
+        self.chat(id!(chat)).write().bot_context = Some(context.clone());
 
         let ui = self.ui_runner();
         spawn(async move {
-            let errors = repo.load().await.into_errors();
+            let errors = context.load().await.into_errors();
 
             ui.defer_with_redraw(move |me, _cx, _scope| {
                 let mut chat = me.chat(id!(chat));
                 let mut messages = chat.read().messages_ref();
 
-                me.fill_selector(repo.bots());
+                me.fill_selector(context.bots());
                 chat.write().visible = true;
 
                 for error in errors {

--- a/moly-mini/src/tester_client.rs
+++ b/moly-mini/src/tester_client.rs
@@ -14,7 +14,7 @@ impl BotClient for TesterClient {
         moly_future(future)
     }
 
-    fn send_stream(
+    fn send(
         &mut self,
         _bot: &Bot,
         messages: &[Message],

--- a/moly-mini/src/tester_client.rs
+++ b/moly-mini/src/tester_client.rs
@@ -16,7 +16,7 @@ impl BotClient for TesterClient {
 
     fn send(
         &mut self,
-        _bot: &Bot,
+        _bot_id: &BotId,
         messages: &[Message],
     ) -> MolyStream<'static, ClientResult<MessageContent>> {
         let mut input = messages

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -70,7 +70,7 @@ pub struct Store {
     pub downloads: Downloads,
     pub chats: Chats,
     pub preferences: Preferences,
-    pub bot_repo: Option<BotRepo>,
+    pub bot_context: Option<BotContext>,
     moly_client: MolyClient,
     pub provider_syncing_status: ProviderSyncingStatus,
 }
@@ -100,7 +100,7 @@ impl Store {
             chats: Chats::new(moly_client.clone()),
             moly_client,
             preferences,
-            bot_repo: None,
+            bot_context: None,
             provider_syncing_status: ProviderSyncingStatus::NotSyncing,
         };
 
@@ -375,10 +375,10 @@ impl Store {
         // Update in preferences (persist in disk)
         self.preferences.insert_or_update_provider(provider);
         // Update in MolyKit (to update the API key used by the client, if needed)
-        if let Some(_bot_repo) = &self.bot_repo {
-            // Because MolyKit does not currently expose an API to update the clients, we'll remove and recreate the entire bot repo
+        if let Some(_bot_context) = &self.bot_context {
+            // Because MolyKit does not currently expose an API to update the clients, we'll remove and recreate the entire bot context
             // TODO(MolyKit): Find a better way to do this
-            self.bot_repo = None;
+            self.bot_context = None;
         }
     }
 


### PR DESCRIPTION
- Renamed `BotRepo` to `BotContext` to not confuse with repository pattern.
- Removed one-time `send` method from `BotClient`, and renamed `send_stream` to just `send`.