### PR TITLE
Fix missing init events

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -135,7 +135,24 @@ live_design! {
                 height: Fill,
                 padding: 0
 
-                root = <View> {
+                // View that shows by default, eventually gets replaced by the root view.
+                loading_view = <View> {
+                    align: {x: 0.5, y: 0.5}
+                    flow: Down, spacing: 20
+                    <Image> {
+                        width: 100, height: 100,
+                        source: (ICON_MOLYSERVER),
+                    }
+                    <Label> {
+                        text: "Loading..."
+                        draw_text: {
+                            text_style: <THEME_FONT_BOLD> { font_size: 12 }
+                            color: #444
+                        }
+                    }
+                }
+
+                root = {{MolyRoot}} {
                     width: Fill,
                     height: Fill,
                     show_bg: true,
@@ -230,10 +247,15 @@ impl AppMain for App {
             Store::load_into_app();
         }
 
+        // If the store is not loaded, do not continue with store-dependent logic
+        // however, we still want the window to handle Makepad events. (e.g. window initialization events, platform context changes, etc.)
         let Some(store) = self.store.as_mut() else {
+            self.ui.handle_event(cx, event, &mut Scope::empty());
             return;
         };
-
+        
+        self.ui.view(id!(loading_view)).set_visible(cx, false);
+        
         // It triggers when the timer expires.
         if self.timer.is_event(event).is_some() {
             if let Some(file_id) = &self.file_id {
@@ -459,4 +481,29 @@ pub enum NavigationAction {
 pub fn app_runner() -> UiRunner<App> {
     // `0` is reserved for whatever implements `AppMain`.
     UiRunner::new(0)
+}
+
+
+/// A wrapper around the main Moly view, used to prevent draw/events
+/// from being propagated to the all of Moly if the store is not loaded.
+#[derive(Live, Widget, LiveHook)]
+pub struct MolyRoot {
+    #[deref]
+    view: View   
+}
+
+impl Widget for MolyRoot {
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        if scope.data.get::<Store>().is_none() {
+            return DrawStep::done();
+        }
+        self.view.draw_walk(cx, scope, walk)
+    }
+
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if scope.data.get::<Store>().is_none() {
+            return;
+        }
+        self.view.handle_event(cx, event, scope);
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -253,9 +253,9 @@ impl AppMain for App {
             self.ui.handle_event(cx, event, &mut Scope::empty());
             return;
         };
-        
+
         self.ui.view(id!(loading_view)).set_visible(cx, false);
-        
+
         // It triggers when the timer expires.
         if self.timer.is_event(event).is_some() {
             if let Some(file_id) = &self.file_id {
@@ -483,13 +483,12 @@ pub fn app_runner() -> UiRunner<App> {
     UiRunner::new(0)
 }
 
-
 /// A wrapper around the main Moly view, used to prevent draw/events
 /// from being propagated to the all of Moly if the store is not loaded.
 #[derive(Live, Widget, LiveHook)]
 pub struct MolyRoot {
     #[deref]
-    view: View   
+    view: View,
 }
 
 impl Widget for MolyRoot {


### PR DESCRIPTION
### Changes

Previously we were dropping events in `app.rs` whenever the store wasn't loaded:
```rs
        let Some(store) = self.store.as_mut() else {
            self.ui.handle_event(cx, event, &mut Scope::empty());
            return;
        };
```
This was causing some makepad "setup" events like window geometry changes to be "dropped" by not being propagated to the main window (`self.ui.handle_event` wasn't called).

This PR fixes this issue by always calling `ui.handle_event`, and introducing a wrapper around the main Moly view, that only propagates events/draws downwards if the store is loaded. Almost the same as before but one level after the App struct.


Added a simple loading screen which we can animate later (almost impossible to see on native due to the store loading so quickly).

https://github.com/user-attachments/assets/43bf54a5-008c-48a5-87cd-0af252017ace




