### PR TITLE
Fix start chat navigation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -349,9 +349,13 @@ impl MatchEvent for App {
                 _ => {}
             }
 
-            if let ChatAction::Start(_) = action.cast() {
-                let chat_radio_button = self.ui.radio_button(id!(chat_tab));
-                chat_radio_button.select(cx, &mut Scope::empty());
+            match action.cast() {
+                ChatAction::Start(_) | ChatAction::StartWithoutEntity => {
+                    let chat_radio_button = self.ui.radio_button(id!(chat_tab));
+                    chat_radio_button.select(cx, &mut Scope::empty());
+                    navigate_to_chat = true;
+                }
+                _ => {}
             }
 
             if let NavigationAction::NavigateToMyModels = action.cast() {


### PR DESCRIPTION
## Summary
- ensure pressing Start Chat selects the Chat tab and navigates immediately

## Testing
- `cargo test --all-features` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852ce4c27cc8324a8cc48ef50127e30