### PR TITLE
Fix issue 518

### DIFF
--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -239,6 +239,22 @@ impl Store {
     fn update_downloads(&mut self) {
         let completed_download_ids = self.downloads.refresh_downloads_data();
 
+        if !completed_download_ids.is_empty() {
+            if let Some(provider) = self
+                .chats
+                .providers
+                .get(&self.moly_client.address())
+                .cloned()
+            {
+                if provider.provider_type == ProviderType::MolyServer && provider.enabled {
+                    self.chats.test_provider_and_fetch_models(
+                        &provider.url,
+                        &mut self.provider_syncing_status,
+                    );
+                }
+            }
+        }
+
         // For search results let's trust on our local cache, but updating
         // the downloaded state of the files
         for file_id in completed_download_ids {


### PR DESCRIPTION
## Summary
- refresh the MolyServer provider once a model download completes

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6854599fb6d083249017f10dab644bac