### PR TITLE
Simplify boxed types at `asynchronous.rs`

### DIFF
--- a/moly-kit/src/clients/deep_inquire.rs
+++ b/moly-kit/src/clients/deep_inquire.rs
@@ -1,5 +1,6 @@
 use crate::utils::errors::enrich_http_error;
 use crate::{protocol::*, utils::sse::parse_sse};
+use crate::utils::asynchronous::{BoxPlatformSendFuture, BoxPlatformSendStream};
 use async_stream::stream;
 use makepad_widgets::*;
 use makepad_widgets::{Cx, LiveNew, WidgetRef};
@@ -191,7 +192,7 @@ impl DeepInquireClient {
 }
 
 impl BotClient for DeepInquireClient {
-    fn bots(&self) -> MolyFuture<'static, ClientResult<Vec<Bot>>> {
+    fn bots(&self) -> BoxPlatformSendFuture<'static, ClientResult<Vec<Bot>>> {
         let inner = self.0.read().unwrap().clone();
 
         // For now we return a hardcoded bot because DeepInquire does not support a /models endpoint
@@ -203,7 +204,7 @@ impl BotClient for DeepInquireClient {
 
         let future = async move { ClientResult::new_ok(vec![bot]) };
 
-        moly_future(future)
+        Box::pin(future)
     }
 
     fn clone_box(&self) -> Box<dyn BotClient> {
@@ -214,7 +215,7 @@ impl BotClient for DeepInquireClient {
         &mut self,
         bot_id: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, ClientResult<MessageContent>> {
+    ) -> BoxPlatformSendStream<'static, ClientResult<MessageContent>> {
         let inner = self.0.read().unwrap().clone();
 
         let url = format!("{}/chat/completions", inner.url);
@@ -334,7 +335,7 @@ impl BotClient for DeepInquireClient {
             yield ClientResult::new_ok(content.clone());
         };
 
-        moly_stream(stream)
+        Box::pin(stream)
     }
 
     fn content_widget(

--- a/moly-kit/src/clients/deep_inquire.rs
+++ b/moly-kit/src/clients/deep_inquire.rs
@@ -1,6 +1,6 @@
+use crate::utils::asynchronous::{BoxPlatformSendFuture, BoxPlatformSendStream};
 use crate::utils::errors::enrich_http_error;
 use crate::{protocol::*, utils::sse::parse_sse};
-use crate::utils::asynchronous::{BoxPlatformSendFuture, BoxPlatformSendStream};
 use async_stream::stream;
 use makepad_widgets::*;
 use makepad_widgets::{Cx, LiveNew, WidgetRef};

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -7,6 +7,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use crate::utils::asynchronous::{BoxPlatformSendFuture, BoxPlatformSendStream};
 use crate::utils::{serde::deserialize_null_default, sse::parse_sse};
 use crate::{protocol::*, utils::errors::enrich_http_error};
 
@@ -245,7 +246,7 @@ impl OpenAIClient {
 }
 
 impl BotClient for OpenAIClient {
-    fn bots(&self) -> MolyFuture<'static, ClientResult<Vec<Bot>>> {
+    fn bots(&self) -> BoxPlatformSendFuture<'static, ClientResult<Vec<Bot>>> {
         let inner = self.0.read().unwrap().clone();
 
         let url = format!("{}/models", inner.url);
@@ -327,7 +328,7 @@ impl BotClient for OpenAIClient {
             ClientResult::new_ok(bots)
         };
 
-        moly_future(future)
+        Box::pin(future)
     }
 
     fn clone_box(&self) -> Box<dyn BotClient> {
@@ -339,7 +340,7 @@ impl BotClient for OpenAIClient {
         &mut self,
         bot_id: &BotId,
         messages: &[Message],
-    ) -> MolyStream<'static, ClientResult<MessageContent>> {
+    ) -> BoxPlatformSendStream<'static, ClientResult<MessageContent>> {
         let bot_id = bot_id.clone();
         let messages = messages.to_vec();
 
@@ -470,7 +471,7 @@ impl BotClient for OpenAIClient {
             }
         };
 
-        moly_stream(stream)
+        Box::pin(stream)
     }
 }
 

--- a/moly-kit/src/utils/asynchronous.rs
+++ b/moly-kit/src/utils/asynchronous.rs
@@ -11,10 +11,7 @@
 //! tied to its own event loop, we need to run Tokio on a separate thread which causes
 //! problems with `Send`.
 
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-};
+use std::pin::Pin;
 
 use futures::{
     future::{AbortHandle, Abortable, Future, abortable},

--- a/moly-kit/src/utils/asynchronous.rs
+++ b/moly-kit/src/utils/asynchronous.rs
@@ -1,9 +1,15 @@
 //! Asynchronous utilities for MolyKit.
 //!
-//! Mainly helps you to deal with the runtime differences across native and web.
+//! Mainly helps you to deal with the runtime differences across native and web
+//! and do workaround integrations of async code in Makepad.
 //!
-//! For example: `reqwest` gives you a `Send` future in native, but on web it uses a `JsValue`
-//! so its future is not send there.
+//! For example: `rfd::FileHandle` is `Send` on native, but not on web. And on web
+//! it may need to be send back to the UI through `Cx::post_action` which requires
+//! `Send` unconditionally.
+//!
+//! Since Makepad doesn't expose an equivalent to `wasm_bindgen_futures::spawn_local`
+//! tied to its own event loop, we need to run Tokio on a separate thread which causes
+//! problems with `Send`.
 
 use std::{
     pin::Pin,
@@ -40,6 +46,12 @@ impl<F, O> PlatformSendFuture for F where F: Future<Output = O> + PlatformSend {
 /// A stream that requires [`Send`] on native platforms, but not on WASM.
 pub trait PlatformSendStream: Stream + PlatformSend {}
 impl<S, T> PlatformSendStream for S where S: Stream<Item = T> + PlatformSend {}
+
+/// An owned dynamically typed Future that only requires [`Send`] on native platforms, but not on WASM.
+pub type BoxPlatformSendFuture<'a, T> = Pin<Box<dyn PlatformSendFuture<Output = T> + 'a>>;
+
+/// An owned dynamically typed Stream that only requires [`Send`] on native platforms, but not on WASM.
+pub type BoxPlatformSendStream<'a, T> = Pin<Box<dyn PlatformSendStream<Item = T> + 'a>>;
 
 /// Runs a future independently, in a platform-specific way.
 ///
@@ -121,44 +133,6 @@ where
 {
     let (abort_handle, abort_registration) = abortable(future);
     (abort_handle, AbortOnDropHandle(abort_registration))
-}
-
-/// Opaque, boxed and pinned future commonly expected by traits in MolyKit.
-///
-/// This future requires [`Send`] only on native platforms, but not on WASM.
-///
-/// Use [`moly_future`] to create an instance of this type.
-pub struct MolyFuture<'a, T>(Pin<Box<dyn PlatformSendFuture<Output = T> + 'a>>);
-impl<'a, T> Future for MolyFuture<'a, T> {
-    type Output = T;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.0).poll(cx)
-    }
-}
-
-/// Opaque, boxed and pinned stream commonly expected by traits in MolyKit.
-///
-/// This stream requires [`Send`] only on native platforms, but not on WASM.
-///
-/// Use [`moly_stream`] to create an instance of this type.
-pub struct MolyStream<'a, T>(Pin<Box<dyn PlatformSendStream<Item = T> + 'a>>);
-impl<'a, T> Stream for MolyStream<'a, T> {
-    type Item = T;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.0).poll_next(cx)
-    }
-}
-
-/// Wraps a future into a [`MolyFuture`].
-pub fn moly_future<'a, T>(future: impl PlatformSendFuture<Output = T> + 'a) -> MolyFuture<'a, T> {
-    MolyFuture(Box::pin(future))
-}
-
-/// Wraps a stream into a [`MolyStream`].
-pub fn moly_stream<'a, T>(stream: impl PlatformSendStream<Item = T> + 'a) -> MolyStream<'a, T> {
-    MolyStream(Box::pin(stream))
 }
 
 mod thread_token {

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -3,6 +3,7 @@ use makepad_widgets::*;
 use std::cell::{Ref, RefMut};
 use utils::asynchronous::spawn;
 
+use crate::utils::asynchronous::PlatformSendStream;
 use crate::utils::makepad::EventExt;
 use crate::utils::ui_runner::DeferWithRedrawAsync;
 use crate::*;
@@ -333,7 +334,8 @@ impl Chat {
                 }
             };
 
-            let mut message_stream = amortize(client.send(&bot.id, &messages_history_context));
+            let message_stream = amortize(client.send(&bot.id, &messages_history_context));
+            let mut message_stream = std::pin::pin!(message_stream);
             while let Some(result) = message_stream.next().await {
                 // In theory, with the synchroneous defer, if stream messages come
                 // faster than deferred closures are executed, and one closure causes
@@ -643,8 +645,8 @@ impl ChatRef {
 /// Util that wraps the stream of `send()` and gives you a stream less agresive to
 /// the receiver UI regardless of the streaming chunk size.
 fn amortize(
-    input: MolyStream<'static, ClientResult<MessageContent>>,
-) -> MolyStream<'static, ClientResult<MessageContent>> {
+    input: impl PlatformSendStream<Item = ClientResult<MessageContent>> + 'static,
+) -> impl PlatformSendStream<Item = ClientResult<MessageContent>> + 'static {
     // Use utils
     use crate::utils::string::AmortizedString;
     use async_stream::stream;
@@ -654,7 +656,7 @@ fn amortize(
     let mut amortized_reasoning = AmortizedString::default();
 
     // Stream compute
-    let stream = stream! {
+    stream! {
         // Our wrapper stream "activates" when something comes from the underlying stream.
         for await result in input {
             // Transparently yield the result on error and then stop.
@@ -691,7 +693,5 @@ fn amortize(
                 yield ClientResult::new_ok(content.clone());
             }
         }
-    };
-
-    moly_stream(stream)
+    }
 }


### PR DESCRIPTION
## Changes
- Removed the opaque wrapper types `MolyFuture` and `MolyStream` and their associated helper functions.
- Introduced the type aliases `BoxPlatformSendFuture` and `BoxPlatformSendStream` which are based on the `futures` crate boxed type aliases and can be constructed with a standard `Box::pin(...)` call.
- `amortize` function at `chat.rs` avoids an unnecessary dyn allocation.