### PR TITLE
Fix nested dispatch causing out-of-order message synchronization

### DIFF
--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -593,12 +593,10 @@ impl Chat {
             };
             
             let next_index = self.messages_ref().read().messages.len();
-            // Queue task instead of dispatching to avoid nested dispatch
-            self.pending_tasks.push(ChatTask::InsertMessage(next_index, loading_message));
+            self.dispatch(cx, &mut vec![ChatTask::InsertMessage(next_index, loading_message)]);
         }
 
-        // Queue task instead of dispatching to avoid nested dispatch
-        self.pending_tasks.push(ChatTask::ScrollToBottom(false));
+        self.dispatch(cx, &mut vec![ChatTask::ScrollToBottom(false)]);
         self.prompt_input_ref().write().set_stop();
         self.redraw(cx);
 

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -591,9 +591,12 @@ impl Chat {
                 },
                 ..Default::default()
             };
-            
+
             let next_index = self.messages_ref().read().messages.len();
-            self.dispatch(cx, &mut vec![ChatTask::InsertMessage(next_index, loading_message)]);
+            self.dispatch(
+                cx,
+                &mut vec![ChatTask::InsertMessage(next_index, loading_message)],
+            );
         }
 
         self.dispatch(cx, &mut vec![ChatTask::ScrollToBottom(false)]);


### PR DESCRIPTION
### Problem

The ChatView widget was experiencing panics with "Invalid slice range" errors when app error messages were inserted. The root cause was due to some missing task dispatching, specifically the intiial loading message from AI wasn't using an insert task, so if an error ocurred it would be inserted at message loading index + 1, but ChatView didn't have the loading message in its list until it was updated with the stream, making index + 1 out of range.

Adding a dispatch of the loading message caused a different error, a nested dispatch call breaking task execution order between the MolyKit Chat widget and ChatView synchronization:

**Expected vs Actual Task Order (when hooking from ChatView)**

- Expected: `insert(0, user_msg)` → `insert(1, loading_msg)` → `insert(2, error_msg) / or update`
- Actual:   `insert(1, loading_msg)` → `insert(0, user_msg)` → `insert(2, error_msg) / or update`

In short this happened because:
  1. Send task dispatches `insert(0, user_message)`
  2. During Send execution, `insert(1, loading_message)` is dispatched (nested call)
  3. Nested dispatch completes before outer dispatch due to synchronous execution
  4. ChatView receives loading message first, but expects user message at index 0
  5. When error message tries to insert at index 2, ChatView only has 1 message → panic

Or for a more visal demonstration including all the tasks:
```
dispatch([User, Send, Clear])
├─ handle_task(User)
├─ handle_task(Send)
│  └─ handle_send_task()
│     ├─ dispatch([Loading])            <-- Must complete entirely
│     │  └─ handle_task(Loading)
│     │     └─ hook_after()             <-- Queues callback #1
│     ├─ dispatch([ScrollToBottom])     <-- Must complete entirely
│     │  └─ handle_task(ScrollToBottom)
│     │     └─ hook_after()             <-- Queues callback #2
├─ handle_task(Clear)
└─ hook_after()                         <-- Queues callback #3
```

### Solution

Dispatch an InsertMessage task for the loading message, and implement automatic nested dispatch prevention:

  1. Added pending_tasks queue to Chat struct
  2. Modified dispatch() method to detect nested calls via is_hooking flag
  3. Queue tasks during nested calls instead of executing immediately
  4. Process queued tasks after main dispatch completes

```rust
  pub fn dispatch(&mut self, cx: &mut Cx, tasks: &mut Vec<ChatTask>) {
      // Prevent nested dispatch - queue tasks if already dispatching
      if self.is_hooking {
          self.pending_tasks.extend(tasks.iter().cloned());
          return;
      }

      // ... existing dispatch logic ...

      // Process any tasks queued during execution
      if !self.pending_tasks.is_empty() {
          let mut pending = std::mem::take(&mut self.pending_tasks);
          self.dispatch(cx, &mut pending);
      }
  }
```

My first thought was to manually queue nested tasks but I've made it so that as devs we don't have to remember that edge case:
  - Devs can call dispatch() anywhere without worrying about nesting
  - Tasks execute in the sequence they were originally intended