### PR TITLE
Add app-wide and provider-wide MCP server controls

### DIFF
--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -449,10 +449,7 @@ impl OpenAIClient {
     }
 
     pub fn set_tools_enabled(&mut self, enabled: bool) {
-        self.0
-            .write()
-            .unwrap()
-            .tools_enabled = enabled;
+        self.0.write().unwrap().tools_enabled = enabled;
     }
 }
 

--- a/moly-kit/src/clients/openai_realtime.rs
+++ b/moly-kit/src/clients/openai_realtime.rs
@@ -246,6 +246,7 @@ pub struct OpenAIRealtimeClient {
     address: String,
     api_key: Option<String>,
     system_prompt: Option<String>,
+    tools_enabled: bool,
 }
 
 impl OpenAIRealtimeClient {
@@ -254,6 +255,7 @@ impl OpenAIRealtimeClient {
             address,
             api_key: None,
             system_prompt: None,
+            tools_enabled: true, // Default to enabled for backward compatibility
         }
     }
 
@@ -265,6 +267,10 @@ impl OpenAIRealtimeClient {
     pub fn set_system_prompt(&mut self, prompt: &str) -> Result<(), String> {
         self.system_prompt = Some(prompt.to_string());
         Ok(())
+    }
+
+    pub fn set_tools_enabled(&mut self, enabled: bool) {
+        self.tools_enabled = enabled;
     }
 
     pub fn create_realtime_session(
@@ -283,7 +289,12 @@ impl OpenAIRealtimeClient {
         };
 
         let bot_id = bot_id.clone();
-        let tools = tools.to_vec();
+        // Only include tools if they are enabled for this client
+        let tools = if self.tools_enabled {
+            tools.to_vec()
+        } else {
+            Vec::new()
+        };
         let system_prompt = self.system_prompt.clone();
         let future = async move {
             let (event_sender, event_receiver) = futures::channel::mpsc::unbounded();

--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -152,6 +152,7 @@ impl ChatScreen {
                             if let Some(key) = provider.api_key.as_ref() {
                                 let _ = client.set_key(&key);
                             }
+                            client.set_tools_enabled(provider.tools_enabled);
 
                             let mut client = MapClient::from(client);
                             if let Some(icon) = store.get_provider_icon(&provider.name) {
@@ -185,6 +186,7 @@ impl ChatScreen {
                             if let Some(prompt) = provider.system_prompt.as_ref() {
                                 let _ = client.set_system_prompt(&prompt);
                             }
+                            client.set_tools_enabled(provider.tools_enabled);
 
                             multi_client.add_client(Box::new(client));
                         }
@@ -196,6 +198,7 @@ impl ChatScreen {
                             if let Some(key) = provider.api_key.as_ref() {
                                 let _ = client.set_key(&key);
                             }
+                            client.set_tools_enabled(provider.tools_enabled);
 
                             let mut client = MapClient::from(client);
                             if let Some(icon) = store.get_provider_icon(&provider.name) {

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -355,6 +355,7 @@ impl Chats {
             existing_provider.models = provider.models.clone();
             existing_provider.connection_status = provider.connection_status.clone();
             existing_provider.system_prompt = provider.system_prompt.clone();
+            existing_provider.tools_enabled = provider.tools_enabled;
 
             if provider.enabled {
                 self.test_provider_and_fetch_models(&provider.id, provider_syncing_status);

--- a/src/data/mcp_servers.rs
+++ b/src/data/mcp_servers.rs
@@ -49,6 +49,10 @@ fn is_default_enabled(enabled: &bool) -> bool {
     *enabled
 }
 
+fn default_mcp_servers_enabled() -> bool {
+    true
+}
+
 impl McpServer {
     /// Create a new stdio-based MCP server
     pub fn stdio(command: String, args: Vec<String>) -> Self {
@@ -176,11 +180,23 @@ impl McpServer {
 }
 
 /// Represents the complete MCP servers configuration (follows MCP standard format)
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServersConfig {
     pub servers: IndexMap<String, McpServer>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inputs: Vec<InputConfig>,
+    #[serde(default = "default_mcp_servers_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for McpServersConfig {
+    fn default() -> Self {
+        Self {
+            servers: IndexMap::new(),
+            inputs: Vec::new(),
+            enabled: true,
+        }
+    }
 }
 
 impl McpServersConfig {

--- a/src/data/preferences.rs
+++ b/src/data/preferences.rs
@@ -84,6 +84,7 @@ impl Preferences {
             existing_provider.api_key = provider.api_key.clone();
             existing_provider.enabled = provider.enabled;
             existing_provider.system_prompt = provider.system_prompt.clone();
+            existing_provider.tools_enabled = provider.tools_enabled;
         } else {
             self.providers_preferences.push(ProviderPreferences {
                 id: provider.id.clone(),
@@ -99,6 +100,7 @@ impl Preferences {
                     .collect(),
                 was_customly_added: provider.was_customly_added,
                 system_prompt: provider.system_prompt.clone(),
+                tools_enabled: provider.tools_enabled,
             });
         }
         self.save();
@@ -176,6 +178,15 @@ impl Preferences {
         Ok(())
     }
 
+    pub fn set_mcp_servers_enabled(&mut self, enabled: bool) {
+        self.mcp_servers_config.enabled = enabled;
+        self.save();
+    }
+
+    pub fn get_mcp_servers_enabled(&self) -> bool {
+        self.mcp_servers_config.enabled
+    }
+
     /// Migrate providers without IDs by generating them from URLs
     fn migrate_provider_ids(&mut self) {
         let mut needs_save = false;
@@ -211,6 +222,13 @@ pub struct ProviderPreferences {
     /// Custom system prompt for the provider (currently used by Realtime providers)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
+    /// Whether tools (MCP) are enabled for this provider
+    #[serde(default = "default_tools_enabled")]
+    pub tools_enabled: bool,
+}
+
+fn default_tools_enabled() -> bool {
+    true
 }
 
 impl ProviderPreferences {

--- a/src/data/providers.rs
+++ b/src/data/providers.rs
@@ -25,6 +25,13 @@ pub struct Provider {
     /// Custom system prompt for the provider (currently used by Realtime providers)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
+    /// Whether tools (MCP) are enabled for this provider
+    #[serde(default = "default_tools_enabled")]
+    pub tools_enabled: bool,
+}
+
+fn default_tools_enabled() -> bool {
+    true
 }
 
 /// Fetch models for a provider using MolyKit clients

--- a/src/mcp/mcp_servers.rs
+++ b/src/mcp/mcp_servers.rs
@@ -137,7 +137,7 @@ live_design! {
         instructions = <Label> {
             width: Fill, height: Fit
             text: "Add new servers by editing the list under 'servers'. You can copy paste you configuration from other applications like Clade Desktop or VSCode.
-You can also add an \"enabled\": false to disable the server."
+You can also add an \"enabled\": false flag to disable a specific server."
             draw_text: {
                 text_style: {font_size: 11},
                 color: #000
@@ -241,10 +241,10 @@ impl Widget for McpServers {
             self.initialized = true;
             let store = scope.data.get::<Store>().unwrap();
             let mut config = store.get_mcp_servers_config().clone();
-            
+
             // Ensure the local config has the correct enabled state from Store
             config.enabled = store.preferences.get_mcp_servers_enabled();
-            
+
             self.set_mcp_servers_config(cx, config);
         }
     }
@@ -263,9 +263,10 @@ impl McpServers {
             .unwrap_or_else(|_| "{}".to_string());
 
         self.widget(id!(mcp_code_view)).set_text(cx, &display_json);
-        
+
         // Sync the toggle UI to match the config's enabled state
-        self.check_box(id!(servers_enabled_switch)).set_active(cx, self.mcp_servers_config.enabled);
+        self.check_box(id!(servers_enabled_switch))
+            .set_active(cx, self.mcp_servers_config.enabled);
     }
 }
 
@@ -273,21 +274,21 @@ impl WidgetMatchEvent for McpServers {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         if self.view(id!(save_button)).finger_up(actions).is_some() {
             let json_text = self.widget(id!(mcp_code_view)).text();
-            
+
             match McpServersConfig::from_json(&json_text) {
                 Ok(config) => {
                     let store = scope.data.get_mut::<Store>().unwrap();
-                    
+
                     // Update the Store with the new config (including servers)
                     match store.update_mcp_servers_from_json(&json_text) {
                         Ok(()) => {
                             // Also sync the enabled flag to the Store's preferences
                             // (in case it was changed in the JSON)
                             store.set_mcp_servers_enabled(config.enabled);
-                            
+
                             // Update our local config and UI
                             self.set_mcp_servers_config(cx, config);
-                            
+
                             self.label(id!(save_status)).set_text(cx, "");
                             self.redraw(cx);
                         }
@@ -298,7 +299,8 @@ impl WidgetMatchEvent for McpServers {
                     }
                 }
                 Err(e) => {
-                    self.label(id!(save_status)).set_text(cx, &format!("Invalid JSON: {}", e));
+                    self.label(id!(save_status))
+                        .set_text(cx, &format!("Invalid JSON: {}", e));
                     self.redraw(cx);
                 }
             }
@@ -309,14 +311,14 @@ impl WidgetMatchEvent for McpServers {
         if let Some(enabled) = servers_enabled_switch.changed(actions) {
             // Update the local config
             self.mcp_servers_config.enabled = enabled;
-            
+
             // Update the JSON display to show the new enabled state
             let display_json = self
                 .mcp_servers_config
                 .to_json()
                 .unwrap_or_else(|_| "{}".to_string());
             self.widget(id!(mcp_code_view)).set_text(cx, &display_json);
-            
+
             // Sync to Store
             let store = scope.data.get_mut::<Store>().unwrap();
             store.set_mcp_servers_enabled(enabled);

--- a/src/settings/add_provider_modal.rs
+++ b/src/settings/add_provider_modal.rs
@@ -359,6 +359,7 @@ impl WidgetMatchEvent for AddProviderModal {
                     models: vec![],
                     was_customly_added: true,
                     system_prompt: None,
+                    tools_enabled: true,
                 },
                 ProviderType::OpenAIImage => Provider {
                     id: provider_id,
@@ -371,6 +372,7 @@ impl WidgetMatchEvent for AddProviderModal {
                     models: vec![],
                     was_customly_added: true,
                     system_prompt: None,
+                    tools_enabled: true,
                 },
                 ProviderType::MolyServer => Provider {
                     id: provider_id,
@@ -383,6 +385,7 @@ impl WidgetMatchEvent for AddProviderModal {
                     models: vec![],
                     was_customly_added: true,
                     system_prompt: None,
+                    tools_enabled: true,
                 },
                 ProviderType::MoFa => Provider {
                     id: provider_id,
@@ -395,6 +398,7 @@ impl WidgetMatchEvent for AddProviderModal {
                     models: vec![],
                     was_customly_added: true,
                     system_prompt: None,
+                    tools_enabled: true,
                 },
                 ProviderType::DeepInquire => Provider {
                     id: provider_id,
@@ -407,6 +411,7 @@ impl WidgetMatchEvent for AddProviderModal {
                     models: vec![],
                     was_customly_added: true,
                     system_prompt: None,
+                    tools_enabled: true,
                 },
                 ProviderType::OpenAIRealtime => Provider {
                     id: provider_id,
@@ -419,6 +424,7 @@ impl WidgetMatchEvent for AddProviderModal {
                     models: vec![],
                     was_customly_added: true,
                     system_prompt: None,
+                    tools_enabled: true,
                 },
             };
 

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -588,7 +588,9 @@ impl ProviderViewRef {
                 inner.view(id!(system_prompt_group)).set_visible(cx, false);
             }
 
-            if provider.provider_type == ProviderType::OpenAIRealtime || provider.provider_type == ProviderType::OpenAI {
+            if provider.provider_type == ProviderType::OpenAIRealtime
+                || provider.provider_type == ProviderType::OpenAI
+            {
                 inner.view(id!(tools_form_group)).set_visible(cx, true);
             } else {
                 inner.view(id!(tools_form_group)).set_visible(cx, false);


### PR DESCRIPTION
### Changes

- Adds toggles to enable/disable MCP servers application wide, and also at the provider level.

<img width="1282" height="967" alt="image" src="https://github.com/user-attachments/assets/7e515c40-238a-41f6-a65f-46b76bd000bc" />

<img width="1035" height="744" alt="image" src="https://github.com/user-attachments/assets/b33a5c0c-fd5b-44fb-ac90-953e39c28faa" />
