### PR TITLE
Add new EntityId variant for tool results

### DIFF
--- a/moly-kit/src/clients/deep_inquire.rs
+++ b/moly-kit/src/clients/deep_inquire.rs
@@ -41,6 +41,7 @@ impl TryFrom<Message> for OutcomingMessage {
             EntityId::User => Ok(Role::User),
             EntityId::System => Ok(Role::System),
             EntityId::Bot(_) => Ok(Role::Assistant),
+            EntityId::Tool => Err(()), // DeepInquire doesn't support tool role
             EntityId::App => Err(()),
         }?;
 

--- a/moly-kit/src/clients/openai.rs
+++ b/moly-kit/src/clients/openai.rs
@@ -203,6 +203,7 @@ async fn to_outgoing_message(message: Message) -> Result<OutgoingMessage, ()> {
         EntityId::User => Ok(Role::User),
         EntityId::System => Ok(Role::System),
         EntityId::Bot(_) => Ok(Role::Assistant),
+        EntityId::Tool => Ok(Role::Tool),
         EntityId::App => Err(()),
     }?;
 

--- a/moly-kit/src/protocol.rs
+++ b/moly-kit/src/protocol.rs
@@ -165,6 +165,10 @@ pub enum EntityId {
     /// Represents a bot, which is an automated assistant of any kind (model, agent, etc).
     Bot(BotId),
 
+    /// Represents tool execution results and tool-related system messages.
+    /// Maps to the "tool" role in LLM APIs.
+    Tool,
+
     /// This app itself. Normally appears when app specific information must be displayed
     /// (like inline errors).
     ///

--- a/moly-kit/src/utils/tool_execution.rs
+++ b/moly-kit/src/utils/tool_execution.rs
@@ -11,8 +11,8 @@ pub fn create_tool_output_summary(_tool_name: &str, content: &str) -> String {
             }
             // Otherwise return a truncated pretty print
             if let Ok(pretty) = serde_json::to_string_pretty(&obj) {
-                if pretty.len() > 500 {
-                    return format!("{}...", &pretty[..500]);
+                if pretty.len() > 100 {
+                    return format!("{}...", &pretty[..100]);
                 }
                 return pretty;
             }
@@ -20,8 +20,8 @@ pub fn create_tool_output_summary(_tool_name: &str, content: &str) -> String {
     }
 
     // For non-JSON or simple text, truncate if too long
-    if content.len() > 500 {
-        format!("{}...", &content[..500])
+    if content.len() > 100 {
+        format!("{}...", &content[..100])
     } else {
         content.to_string()
     }

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -384,7 +384,7 @@ impl Chat {
             let Some(tool_manager) = context.tool_manager() else {
                 ui.defer_with_redraw(move |me, cx, _| {
                     let error_message = Message {
-                        from: EntityId::System,
+                        from: EntityId::Tool,
                         content: MessageContent {
                             text: "Tool execution failed: Tool manager not available".to_string(),
                             ..Default::default()
@@ -429,7 +429,7 @@ impl Chat {
                             &result.content,
                         );
                         format!(
-                            "🔧 Tool '{}' executed successfully:\n{}",
+                            "🔧 Tool '{}' executed successfully:\n`{}`",
                             display_name, summary
                         )
                     }
@@ -453,7 +453,7 @@ impl Chat {
                                 tool_name,
                                 &result.content,
                             );
-                            text.push_str(&format!("**{}** ✅: {}\n\n", display_name, summary));
+                            text.push_str(&format!("**{}** ✅: `{}`\n\n", display_name, summary));
                         }
                     }
                     text
@@ -461,7 +461,7 @@ impl Chat {
 
                 // Update the existing loading message with tool results
                 let updated_message = Message {
-                    from: EntityId::System, // Tool results are system messages
+                    from: EntityId::Tool, // Tool results use the tool role
                     content: MessageContent {
                         text: results_text,
                         tool_results,
@@ -781,7 +781,7 @@ impl Chat {
                     };
 
                     let loading_message = Message {
-                        from: EntityId::System,
+                        from: EntityId::Tool,
                         content: MessageContent {
                             text: loading_text,
                             ..Default::default()
@@ -841,7 +841,7 @@ impl Chat {
 
                     // Add tool result message with denial results
                     let tool_message = Message {
-                        from: EntityId::System,
+                        from: EntityId::Tool,
                         content: MessageContent {
                             text: "🚫 Tool execution was denied by the user.".to_string(),
                             tool_results,
@@ -991,8 +991,6 @@ impl Chat {
                                 .unwrap_or(false)
                         })
                         .unwrap_or(false);
-
-                    println!("Dangerous mode: {}", dangerous_mode_enabled);
 
                     if dangerous_mode_enabled {
                         // Auto-approve tool calls in dangerous mode

--- a/moly-kit/src/widgets/chat_lines.rs
+++ b/moly-kit/src/widgets/chat_lines.rs
@@ -233,7 +233,8 @@ live_design! {
         }
     }
 
-    pub ToolLine = <SystemLine> {
+    // Line for tool permission requests (from assistant asking to use a tool)
+    pub ToolRequestLine = <AppLine> {
         message_section = {
             draw_bg: {color: #fff3e0}
 
@@ -241,7 +242,6 @@ live_design! {
                 avatar = {
                     grapheme = {draw_bg: {color: #ff9800}}
                 }
-                name = {text: "Permission Request"}
             }
             content_section = {
                 flow: Down
@@ -257,6 +257,19 @@ live_design! {
                             color: #000
                         }
                     }
+                }
+            }
+        }
+    }
+
+    // Line for tool execution results (EntityId::Tool)
+    pub ToolResultLine = <AppLine> {
+        message_section = {
+            draw_bg: {color: #cfe4ff}
+
+            sender = {
+                avatar = {
+                    grapheme = {draw_bg: {color: #1a5b9c}}
                 }
             }
         }

--- a/moly-kit/src/widgets/realtime.rs
+++ b/moly-kit/src/widgets/realtime.rs
@@ -422,7 +422,7 @@ live_design! {
             }
         }
 
-        tool_permission_line = <ToolLine> {
+        tool_permission_line = <ToolRequestLine> {
             visible: false
             margin: {left: 10, right: 10, top: 10}
         }
@@ -790,7 +790,7 @@ impl WidgetMatchEvent for Realtime {
             self.update_ui(cx);
         }
 
-        // Handle tool permission buttons from ToolLine
+        // Handle tool permission buttons from ToolRequestLine
         if self
             .view(id!(tool_permission_line))
             .button(id!(message_section.content_section.tool_actions.approve))


### PR DESCRIPTION
Introduces `EntityId::Tool` for tool call results, we were previously using `EntityId::System` which should be used for things like system prompts instead.

New EntityId usage:
```
- User message → `EntityId::User` (unchanged)
- Assistant response with tool calls → EntityId::Bot(bot_id) // these are regular messages that also include tool calls, some providers even include a reglar text like "yes, let me navigate to wikipedia", and alongside that the tool call.
- Tool execution results → EntityId::Tool (new variant)
- Assistant response to tool results → EntityId::Bot(bot_id)
- System prompts/context → EntityId::System (unchanged)
- App errors/notifications → EntityId::App (unchanged)
```